### PR TITLE
Telemetry

### DIFF
--- a/server/inference-server/scheduler/trusted/Cargo.toml
+++ b/server/inference-server/scheduler/trusted/Cargo.toml
@@ -1,7 +1,7 @@
 cargo-features = ["resolver"]
 [package]
 name = "inference_server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Mithril Security"]
 resolver = "2"

--- a/server/inference-server/scheduler/trusted/Enclave.edl
+++ b/server/inference-server/scheduler/trusted/Enclave.edl
@@ -33,7 +33,9 @@ enclave {
     trusted
     {
         /* ECALLs */
-        public sgx_status_t start_server();
+        public sgx_status_t start_server(
+            [in, string] char *telemetry_platform,
+            [in, string] char *telemetry_uid);
     };
     untrusted
     {

--- a/server/inference-server/scheduler/trusted/Xargo.toml
+++ b/server/inference-server/scheduler/trusted/Xargo.toml
@@ -64,7 +64,7 @@ stage = 4
 [dependencies.std]
 path = "../../../sdk/xargo/sgx_tstd"
 stage = 5
-features = ["backtrace", "net", "thread", "untrusted_time", "untrusted_fs"]
+features = ["backtrace", "net", "thread", "untrusted_time"]
 
 [dependencies.sgx_no_tstd]
 path = "../../../sdk/sgx_no_tstd"

--- a/server/inference-server/scheduler/trusted/Xargo.toml
+++ b/server/inference-server/scheduler/trusted/Xargo.toml
@@ -64,7 +64,7 @@ stage = 4
 [dependencies.std]
 path = "../../../sdk/xargo/sgx_tstd"
 stage = 5
-features = ["backtrace", "net", "thread", "untrusted_time"]
+features = ["backtrace", "net", "thread", "untrusted_time", "untrusted_fs"]
 
 [dependencies.sgx_no_tstd]
 path = "../../../sdk/sgx_no_tstd"

--- a/server/inference-server/scheduler/trusted/src/lib.rs
+++ b/server/inference-server/scheduler/trusted/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![crate_name = "inference_server"]
 #![crate_type = "staticlib"]
+#![feature(once_cell)]
 
 extern crate env_logger;
 extern crate sgx_libc;
@@ -86,6 +87,7 @@ use crate::client_communication::{
 };
 
 use crate::dcap_quote_provider::DcapQuoteProvider;
+use crate::telemetry::TelemetryEventProps;
 
 use untrusted::MyAttestation;
 
@@ -95,6 +97,7 @@ mod client_communication;
 mod dcap_quote_provider;
 mod identity;
 mod untrusted;
+mod telemetry;
 
 #[no_mangle]
 pub extern "C" fn start_server() -> sgx_status_t {
@@ -171,6 +174,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "Server running in simulation mode, attestation not available."
         );
     }
+
+    telemetry::setup()?;
+    telemetry::add_event(TelemetryEventProps::Started {});
 
     server_future.await?;
 

--- a/server/inference-server/scheduler/trusted/src/lib.rs
+++ b/server/inference-server/scheduler/trusted/src/lib.rs
@@ -182,7 +182,11 @@ async fn main(telemetry_platform: String, telemetry_uid: String) -> Result<(), B
         );
     }
 
-    telemetry::setup(telemetry_platform, telemetry_uid)?;
+    if !std::env::var("BLINDAI_DISABLE_TELEMETRY").is_ok() {
+        telemetry::setup(telemetry_platform, telemetry_uid)?;
+    } else {
+        debug!("Telemetry is disabled.")
+    }
     telemetry::add_event(TelemetryEventProps::Started {});
 
     server_future.await?;

--- a/server/inference-server/scheduler/trusted/src/telemetry.rs
+++ b/server/inference-server/scheduler/trusted/src/telemetry.rs
@@ -123,7 +123,7 @@ pub fn setup(platform: String, uid: String) -> anyhow::Result<()> {
                 }
             }
 
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(3)).await;
         }
     });
 

--- a/server/inference-server/scheduler/trusted/src/telemetry.rs
+++ b/server/inference-server/scheduler/trusted/src/telemetry.rs
@@ -123,7 +123,7 @@ pub fn setup(platform: String, uid: String) -> anyhow::Result<()> {
                 }
             }
 
-            tokio::time::sleep(Duration::from_secs(10 * 60)).await;
+            tokio::time::sleep(Duration::from_secs(60)).await;
         }
     });
 

--- a/server/inference-server/scheduler/trusted/src/telemetry.rs
+++ b/server/inference-server/scheduler/trusted/src/telemetry.rs
@@ -1,0 +1,138 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    lazy::SyncOnceCell,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use log::debug;
+use serde::Serialize;
+use tokio::sync::mpsc::{self, UnboundedSender};
+
+const AMPLITUDE_API_KEY: &str = "33888bd644f1dc39f72f2963c944c94c";
+
+static TELEMETRY_CHANNEL: SyncOnceCell<UnboundedSender<TelemetryEvent>> = SyncOnceCell::new();
+
+#[derive(Debug, Serialize)]
+pub enum TelemetryEventProps {
+    Started {},
+    SendModel { model_size: usize },
+    RunModel {},
+}
+
+pub struct TelemetryEvent {
+    props: TelemetryEventProps,
+    time: SystemTime,
+}
+
+impl TelemetryEventProps {
+    fn event_type(&self) -> &'static str {
+        match self {
+            TelemetryEventProps::Started { .. } => "started",
+            TelemetryEventProps::SendModel { .. } => "send_model",
+            TelemetryEventProps::RunModel { .. } => "run_model",
+        }
+    }
+}
+
+pub fn add_event(event: TelemetryEventProps) {
+    let sender = TELEMETRY_CHANNEL.get().expect("telemetry not initialized");
+
+    let _ = sender.send(TelemetryEvent {
+        props: event,
+        time: SystemTime::now(),
+    });
+}
+
+#[derive(Debug, Serialize)]
+struct RequestEvent<'a> {
+    user_id: &'a str,
+    event_type: &'a str,
+    device_id: &'a str,
+    time: u64,
+    app_version: &'a str,
+    user_properties: ReqestUserProperties<'a>,
+    event_properties: Option<TelemetryEventProps>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReqestUserProperties<'a> {
+    sgx_mode: &'a str,
+    uptime: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct AmplitudeRequest<'a> {
+    api_key: &'a str,
+    events: &'a Vec<RequestEvent<'a>>,
+}
+
+pub fn setup() -> anyhow::Result<()> {
+    let (sender, mut receiver) = mpsc::unbounded_channel::<TelemetryEvent>();
+
+    TELEMETRY_CHANNEL.set(sender).unwrap();
+
+    let sgx_mode = if cfg!(SGX_MODE = "SW") { "SW" } else { "HW" };
+    let platform = format!("Linux SGX-{}", sgx_mode);
+
+    let mut hasher = DefaultHasher::new();
+    platform.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let uid = format!("{:X}", hash);
+    let first_start = SystemTime::now();
+
+    tokio::task::spawn(async move {
+        loop {
+            let mut events = Vec::new();
+            while let Ok(properties) = receiver.try_recv() {
+                let event_type = properties.props.event_type();
+                let user_properties = ReqestUserProperties {
+                    uptime: properties
+                        .time
+                        .duration_since(first_start)
+                        .unwrap()
+                        .as_secs(),
+                    sgx_mode,
+                };
+
+                let event = RequestEvent {
+                    user_id: &uid,
+                    event_type,
+                    device_id: &platform,
+                    time: properties
+                        .time
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs(),
+                    app_version: env!("CARGO_PKG_VERSION"),
+                    user_properties,
+                    event_properties: Some(properties.props),
+                };
+
+                events.push(event);
+            }
+
+            let request = AmplitudeRequest {
+                api_key: AMPLITUDE_API_KEY,
+                events: &events,
+            };
+
+            if events.len() > 0 {
+                let response = reqwest::Client::new()
+                    .post("https://api2.amplitude.com/2/httpapi")
+                    .timeout(Duration::from_secs(60))
+                    .json(&request)
+                    .send()
+                    .await;
+                if let Err(e) = response {
+                    debug!("Cannot contact telemetry server: {}", e);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(60 * 60)).await;
+        }
+    });
+
+    Ok(())
+}

--- a/server/inference-server/scheduler/trusted/src/telemetry.rs
+++ b/server/inference-server/scheduler/trusted/src/telemetry.rs
@@ -36,12 +36,13 @@ impl TelemetryEventProps {
 }
 
 pub fn add_event(event: TelemetryEventProps) {
-    let sender = TELEMETRY_CHANNEL.get().expect("telemetry not initialized");
-
-    let _ = sender.send(TelemetryEvent {
-        props: event,
-        time: SystemTime::now(),
-    });
+    if let Some(sender) = TELEMETRY_CHANNEL.get() {
+        let _ = sender.send(TelemetryEvent {
+            props: event,
+            time: SystemTime::now(),
+        });
+    }
+    // else, telemetry is disabled
 }
 
 #[derive(Debug, Serialize)]
@@ -122,7 +123,7 @@ pub fn setup(platform: String, uid: String) -> anyhow::Result<()> {
                 }
             }
 
-            tokio::time::sleep(Duration::from_secs(30 * 60)).await;
+            tokio::time::sleep(Duration::from_secs(10 * 60)).await;
         }
     });
 

--- a/server/inference-server/scheduler/trusted/src/telemetry.rs
+++ b/server/inference-server/scheduler/trusted/src/telemetry.rs
@@ -67,21 +67,13 @@ struct AmplitudeRequest<'a> {
     events: &'a Vec<RequestEvent<'a>>,
 }
 
-pub fn setup() -> anyhow::Result<()> {
+pub fn setup(platform: String, uid: String) -> anyhow::Result<()> {
     let (sender, mut receiver) = mpsc::unbounded_channel::<TelemetryEvent>();
 
     TELEMETRY_CHANNEL.set(sender).unwrap();
-
     let sgx_mode = if cfg!(SGX_MODE = "SW") { "SW" } else { "HW" };
-    let platform = format!("Linux SGX-{}", sgx_mode);
 
-    let mut hasher = DefaultHasher::new();
-    platform.hash(&mut hasher);
-    let hash = hasher.finish();
-
-    let uid = format!("{:X}", hash);
     let first_start = SystemTime::now();
-
     tokio::task::spawn(async move {
         loop {
             let mut events = Vec::new();
@@ -130,7 +122,7 @@ pub fn setup() -> anyhow::Result<()> {
                 }
             }
 
-            tokio::time::sleep(Duration::from_secs(60 * 60)).await;
+            tokio::time::sleep(Duration::from_secs(30 * 60)).await;
         }
     });
 

--- a/server/inference-server/scheduler/untrusted/Cargo.lock
+++ b/server/inference-server/scheduler/untrusted/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "tonic-build",
  "tonic-rpc",
  "webpki",
+ "whoami",
  "x509-parser",
 ]
 
@@ -1644,6 +1645,16 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/server/inference-server/scheduler/untrusted/Cargo.toml
+++ b/server/inference-server/scheduler/untrusted/Cargo.toml
@@ -36,6 +36,7 @@ pem = "1.0.1"
 base16 = "0.2.1"
 webpki = "0.21.4"
 toml = "*"
+whoami = "1.2.1"
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/server/inference-server/scheduler/untrusted/Cargo.toml
+++ b/server/inference-server/scheduler/untrusted/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 name = "app"
 version = "1.0.0"
 edition = "2018"
-authors = ["Teaclave"]
+authors = ["Mithril Security"]
 build = "build.rs"
 
 [dependencies] # You can specify the features you need for urts, such as global_exit and global_init


### PR DESCRIPTION
User identifier is created in the untrusted side, and passed to the enclave afterwards. This is because systemcalls to get hostnames & other infos are not available in the enclave.

Events are put in a queue (an unbounded mpsc channel currently) to be sent later. A background task batches all the events and sends them every 30 minutes.