### PR TITLE
ci: Clippy and cargo audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,23 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: repo
+
+      - run: cp -r repo/server/* .
+
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,11 +1,12 @@
 name: Security audit
-on:
-  push:
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-  schedule:
-    - cron: '0 0 * * *'
+# Temporarily disabled
+on: []
+# push:
+#   paths: 
+#     - '**/Cargo.toml'
+#     - '**/Cargo.lock'
+# schedule:
+#   - cron: '0 0 * * *'
 
 jobs:
   security_audit:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,26 @@
+on: [push]
+name: Clippy
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: repo
+
+      - run: cp -r repo/server/* .
+
+      - name: Install nightly-2021-11-01
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-11-01
+          override: true
+          components: clippy, rustfmt
+
+      - uses: actions-rs/clippy-check@v1
+        with:
+          args: --all-features
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/server/blindai_app/src/dcap.rs
+++ b/server/blindai_app/src/dcap.rs
@@ -232,24 +232,24 @@ fn sgx_get_quote_verification_collateral(
 
     let pck_crl_issuer_chain = unsafe {
         slice::from_raw_parts(
-            (&*p_quote_collateral).pck_crl_issuer_chain as *const u8,
-            (&*p_quote_collateral).pck_crl_issuer_chain_size as usize - 1,
+            (*p_quote_collateral).pck_crl_issuer_chain as *const u8,
+            (*p_quote_collateral).pck_crl_issuer_chain_size as usize - 1,
         )
         .to_owned()
     };
 
     let root_ca_crl = unsafe {
         slice::from_raw_parts(
-            (&*p_quote_collateral).root_ca_crl as *const u8,
-            (&*p_quote_collateral).root_ca_crl_size as usize - 1,
+            (*p_quote_collateral).root_ca_crl as *const u8,
+            (*p_quote_collateral).root_ca_crl_size as usize - 1,
         )
         .to_owned()
     };
 
     let pck_crl = unsafe {
         slice::from_raw_parts(
-            (&*p_quote_collateral).pck_crl as *const u8,
-            (&*p_quote_collateral).pck_crl_size as usize - 1,
+            (*p_quote_collateral).pck_crl as *const u8,
+            (*p_quote_collateral).pck_crl_size as usize - 1,
         )
         .to_owned()
     };
@@ -257,8 +257,8 @@ fn sgx_get_quote_verification_collateral(
     let tcb_info_issuer_chain = {
         let slice = unsafe {
             slice::from_raw_parts(
-                (&*p_quote_collateral).tcb_info_issuer_chain as *const u8,
-                (&*p_quote_collateral).tcb_info_issuer_chain_size as usize - 1,
+                (*p_quote_collateral).tcb_info_issuer_chain as *const u8,
+                (*p_quote_collateral).tcb_info_issuer_chain_size as usize - 1,
             )
         };
         str::from_utf8(slice)?.to_owned()
@@ -267,8 +267,8 @@ fn sgx_get_quote_verification_collateral(
     let tcb_info = {
         let slice = unsafe {
             slice::from_raw_parts(
-                (&*p_quote_collateral).tcb_info as *const u8,
-                (&*p_quote_collateral).tcb_info_size as usize - 1,
+                (*p_quote_collateral).tcb_info as *const u8,
+                (*p_quote_collateral).tcb_info_size as usize - 1,
             )
         };
         str::from_utf8(slice)?.to_owned()
@@ -277,8 +277,8 @@ fn sgx_get_quote_verification_collateral(
     let qe_identity_issuer_chain = {
         let slice = unsafe {
             slice::from_raw_parts(
-                (&*p_quote_collateral).qe_identity_issuer_chain as *const u8,
-                (&*p_quote_collateral).qe_identity_issuer_chain_size as usize - 1,
+                (*p_quote_collateral).qe_identity_issuer_chain as *const u8,
+                (*p_quote_collateral).qe_identity_issuer_chain_size as usize - 1,
             )
         };
         str::from_utf8(slice)?.to_owned()
@@ -287,14 +287,14 @@ fn sgx_get_quote_verification_collateral(
     let qe_identity = {
         let slice = unsafe {
             slice::from_raw_parts(
-                (&*p_quote_collateral).qe_identity as *const u8,
-                (&*p_quote_collateral).qe_identity_size as usize - 1,
+                (*p_quote_collateral).qe_identity as *const u8,
+                (*p_quote_collateral).qe_identity_size as usize - 1,
             )
         };
         str::from_utf8(slice)?.to_owned()
     };
 
-    let version = unsafe { (&*p_quote_collateral).version };
+    let version = unsafe { (*p_quote_collateral).version };
 
     let pck_crl_issuer_chain = pcs_crl_to_pem(&pck_crl_issuer_chain);
     let root_ca_crl = pcs_crl_to_pem(&root_ca_crl);

--- a/server/blindai_sgx/Cargo.toml
+++ b/server/blindai_sgx/Cargo.toml
@@ -48,10 +48,10 @@ x509-parser = "*"
 h2 = "=0.3.4"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
-sgx_libc = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
-sgx_trts = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
+# sgx_libc = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
+# sgx_trts = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
 sgx_tseal = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
-sgx_tstd = {git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["backtrace"]}
+# sgx_tstd = {git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["backtrace"]}
 sgx_types = {git = "https://github.com/apache/teaclave-sgx-sdk.git"}
 
 [build-dependencies]

--- a/server/blindai_sgx/src/identity.rs
+++ b/server/blindai_sgx/src/identity.rs
@@ -38,8 +38,8 @@ where
 
         // Create Identity from the PEM key-pair
         TlsIdentity {
-            cert_der: cert_der,
-            private_key_der: private_key_der,
+            cert_der,
+            private_key_der,
         }
     }
 }
@@ -97,18 +97,17 @@ pub(crate) fn create_certificate() -> Result<(Certificate, RsaKeyPair)> {
 
     let subject_alt_names = Vec::from(subject_alt_names)
         .into_iter()
-        .map(|s| SanType::DnsName(s))
+        .map(SanType::DnsName)
         .collect::<Vec<_>>();
 
     let mut params = CertificateParams::default();
     params.subject_alt_names = subject_alt_names;
 
-    /* OIDs under the Internet Experimental OID arc (1.3.6.1.3.x) may be used for experimental purpose */
+    /* OIDs under the Internet Experimental OID arc (1.3.6.1.3.x) may be used for
+     * experimental purpose */
     let rsa_file_encryption_key_oid: Vec<_> = oid!(1.3.6 .1 .3 .1)
         .iter()
-        .ok_or(anyhow!(
-            "At least one arc of the OID does not fit into `u64`"
-        ))?
+        .ok_or_else(|| anyhow!("At least one arc of the OID does not fit into `u64`"))?
         .collect();
 
     /* create random RSA key pair */
@@ -133,7 +132,7 @@ pub(crate) fn create_certificate() -> Result<(Certificate, RsaKeyPair)> {
     /* add the RSA public key as bytes to the certificate */
     let signing_ext = CustomExtension::from_oid_content(
         &rsa_file_encryption_key_oid,
-        rsa_public_key_bytes.clone(),
+        rsa_public_key_bytes,
     );
 
     params.custom_extensions = vec![signing_ext];

--- a/server/blindai_sgx/src/lib.rs
+++ b/server/blindai_sgx/src/lib.rs
@@ -57,6 +57,8 @@ mod identity;
 mod telemetry;
 mod untrusted;
 
+extern crate sgx_types;
+
 /// # Safety
 ///
 /// `telemetry_platform` and `telemetry_uid` need to be valid C strings.

--- a/server/blindai_sgx/src/lib.rs
+++ b/server/blindai_sgx/src/lib.rs
@@ -16,16 +16,6 @@
 #![crate_type = "staticlib"]
 #![feature(once_cell)]
 
-extern crate env_logger;
-extern crate sgx_libc;
-extern crate sgx_tseal;
-extern crate sgx_types;
-extern crate tract_core;
-extern crate tract_onnx;
-
-extern crate serde_cbor;
-extern crate serde_derive;
-
 use env_logger::Env;
 #[cfg(target_env = "sgx")]
 use std::backtrace::{self, PrintFormat};
@@ -67,8 +57,11 @@ mod identity;
 mod telemetry;
 mod untrusted;
 
+/// # Safety
+///
+/// `telemetry_platform` and `telemetry_uid` need to be valid C strings.
 #[no_mangle]
-pub extern "C" fn start_server(
+pub unsafe extern "C" fn start_server(
     telemetry_platform: *const c_char,
     telemetry_uid: *const c_char,
 ) -> sgx_status_t {
@@ -79,8 +72,8 @@ pub extern "C" fn start_server(
 
     info!("Switched to enclave context");
 
-    let telemetry_platform = unsafe { CStr::from_ptr(telemetry_platform) };
-    let telemetry_uid = unsafe { CStr::from_ptr(telemetry_uid) };
+    let telemetry_platform = CStr::from_ptr(telemetry_platform);
+    let telemetry_uid = CStr::from_ptr(telemetry_uid);
 
     let telemetry_platform = telemetry_platform.to_owned().into_string().unwrap();
     let telemetry_uid = telemetry_uid.to_owned().into_string().unwrap();
@@ -99,6 +92,7 @@ async fn main(
     telemetry_platform: String,
     telemetry_uid: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_env = "sgx")]
     let _ = backtrace::enable_backtrace("enclave.signed.so", PrintFormat::Full);
     let (certificate, storage_identity) = identity::create_certificate()?;
     let my_identity = MyIdentity::from_cert(certificate, storage_identity);
@@ -128,7 +122,7 @@ async fn main(
             Server::builder()
                 .tls_config(ServerTlsConfig::new().identity(untrusted_identity))?
                 .add_service(untrusted::AttestationServer::new(MyAttestation {
-                    quote_provider: &dcap_quote_provider,
+                    quote_provider: dcap_quote_provider,
                 }))
                 .serve(network_config.client_to_enclave_untrusted_socket()?)
                 .await?;
@@ -154,7 +148,7 @@ async fn main(
         info!("Server running in simulation mode, attestation not available.");
     }
 
-    if !std::env::var("BLINDAI_DISABLE_TELEMETRY").is_ok() {
+    if std::env::var("BLINDAI_DISABLE_TELEMETRY").is_err() {
         telemetry::setup(telemetry_platform, telemetry_uid)?;
     } else {
         debug!("Telemetry is disabled.")

--- a/server/blindai_sgx/src/telemetry.rs
+++ b/server/blindai_sgx/src/telemetry.rs
@@ -109,7 +109,7 @@ pub fn setup(platform: String, uid: String) -> anyhow::Result<()> {
                 events: &events,
             };
 
-            if events.len() > 0 {
+            if !events.is_empty() {
                 let response = reqwest::Client::new()
                     .post("https://api2.amplitude.com/2/httpapi")
                     .timeout(Duration::from_secs(60))

--- a/server/blindai_sgx/src/untrusted.rs
+++ b/server/blindai_sgx/src/untrusted.rs
@@ -15,10 +15,10 @@
 use crate::dcap_quote_provider::DcapQuoteProvider;
 use blindai_common::untrusted_local_app_client::UntrustedLocalAppClient;
 use tonic::{Request, Response, Status};
-pub use untrusted::attestation_server::*;
-use untrusted::*;
+pub use untrusted_proto::attestation_server::*;
+use untrusted_proto::*;
 
-pub mod untrusted {
+pub mod untrusted_proto {
     tonic::include_proto!("untrusted");
 }
 
@@ -44,7 +44,7 @@ impl Attestation for MyAttestation {
     ) -> Result<Response<GetTokenReply>, Status> {
         println!("Got a request from {:?}", request.remote_addr());
 
-        let reply = untrusted::GetTokenReply {
+        let reply = GetTokenReply {
             token: "".to_owned(), // token: self.token.lock().unwrap().clone()
         };
         Ok(Response::new(reply))
@@ -74,17 +74,17 @@ impl Attestation for MyAttestation {
         let reply = GetSgxQuoteWithCollateralReply {
             collateral: Some(SgxCollateral {
                 version: collateral.version, // version = 1.  PCK Cert chain is in the Quote.
-                pck_crl_issuer_chain: collateral.pck_crl_issuer_chain.into(),
-                root_ca_crl: collateral.root_ca_crl.into(), // Root CA CRL
-                pck_crl: collateral.pck_crl.into(),         // PCK Cert CRL
-                tcb_info_issuer_chain: collateral.tcb_info_issuer_chain.into(),
-                tcb_info: collateral.tcb_info.into(), // TCB Info structure
-                qe_identity_issuer_chain: collateral.qe_identity_issuer_chain.into(),
-                qe_identity: collateral.qe_identity.into(), // QE Identity Structure
+                pck_crl_issuer_chain: collateral.pck_crl_issuer_chain,
+                root_ca_crl: collateral.root_ca_crl, // Root CA CRL
+                pck_crl: collateral.pck_crl,         // PCK Cert CRL
+                tcb_info_issuer_chain: collateral.tcb_info_issuer_chain,
+                tcb_info: collateral.tcb_info, // TCB Info structure
+                qe_identity_issuer_chain: collateral.qe_identity_issuer_chain,
+                qe_identity: collateral.qe_identity, // QE Identity Structure
                 pck_certificate: collateral.pck_certificate, //PEM encoded PCK certificate
                 pck_signing_chain: collateral.pck_signing_chain, // PEM encoded PCK signing chain such that (pck_certificate || pck_signing_chain) == pck_cert_chain
             }),
-            quote: quote,
+            quote,
             enclave_held_data: self.quote_provider.enclave_held_data.clone(),
         };
         Ok(Response::new(reply))


### PR DESCRIPTION
## Description

Adds a clippy run and cargo audit workflow to the CI.
The clippy run only runs with SGX env disabled. This needed some changes to the blindai_sgx crate so that the code typechecks without SGX env.
I have tried to do a clippy workflow with SGX env (with xargo and stuff) and I couldn't get it to work nicely. I have decided to work on landing this for now and go back to work on that later if we think this is important.

This PR also resolves the issues clippy found with our code.

The cargo dependency audit workflow will run everyday, and when we push any Cargo.lock changes. This workflow currently does not pass, and we should do a PR to fix our dependencies.

This PR does not add a cargo check workflow since clippy does a cargo check itself, and the build_server CI already does one too (but doesn't run clippy).

## Related Issue

#21 

## Type of change

- [ ] This change requires a documentation update
- [ ] This change affects the client
- [x] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

Has been run a bunch of times using the CI until it passes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation according to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
