### PR TITLE
New version tract & fix setup.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,9 +67,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r client/requirements.txt
-          cd client
-          python3 -m grpc_tools.protoc --proto_path=$(realpath proto) --python_out=blindai --grpc_python_out=blindai securedexchange.proto
-          python3 -m grpc_tools.protoc --proto_path=$(realpath proto) --python_out=blindai --grpc_python_out=blindai untrusted.proto
 
       # Build client
 

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,8 +1,8 @@
 # requirements for building
 cryptography>=35.0.0
 toml
-grpcio
-grpcio-tools
+grpcio==1.44.0
+grpcio-tools==1.44.0
 bitstring
 cbor2
 pybind11

--- a/client/setup.py
+++ b/client/setup.py
@@ -4,6 +4,7 @@ import subprocess
 import platform
 import re
 import sys
+import pkg_resources
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
@@ -81,20 +82,21 @@ class BuildPy(build_py):
         # Generate the stub
         dir_path = os.path.join(os.path.dirname(__file__))
         proto_path = os.path.join(dir_path, "proto")
+        proto_include = pkg_resources.resource_filename('grpc_tools', '_proto')
         import grpc_tools.protoc
-
-        print(dir_path, proto_files, proto_path)
 
         for file in proto_files:
             grpc_tools.protoc.main(
                 [
                     "grpc_tools.protoc",
+                    "-I{}".format(proto_include),
                     "--proto_path={}".format(proto_path),
                     "--python_out=blindai",
                     "--grpc_python_out=blindai",
                     "{}".format(file),
                 ]
             )
+
         # Build the AttestationLib
         build_script = os.path.join(os.path.dirname(__file__), "scripts/build.sh")
         subprocess.check_call([build_script])
@@ -121,8 +123,8 @@ setuptools.setup(
     install_requires=[
         "cryptography>=35.0.0",
         "toml",
-        "grpcio==1.45",
-        "grpcio-tools==1.45",
+        "grpcio==1.44",
+        "grpcio-tools==1.44",
         "bitstring",
         "cbor2",
     ],
@@ -133,8 +135,8 @@ setuptools.setup(
             "wheel",
             "check-wheel-contents",
             "auditwheel",
-            "grpcio-tools==1.45",
-            "grpcio==1.45",
+            "grpcio-tools==1.44",
+            "grpcio==1.44",
         ]
     },
     classifiers=[

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -822,7 +822,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -867,7 +867,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -968,6 +968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,9 +1027,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "liquid"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e930310cf4334c4936ae18737500a57739c69442b5c42bae114d619af54b82"
+checksum = "cb6e6551b4c8a2045351f0853b54807b21080176a055b754dc0ad29428edf293"
 dependencies = [
  "doc-comment",
  "kstring",
@@ -1035,12 +1041,11 @@ dependencies = [
 
 [[package]]
 name = "liquid-core"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75813224dc11c55e2949b764742882ac291e8b99673a97354277208ca59df6e"
+checksum = "8ea8f6c13e8ae36bce67fc1eaacf32c13b26d16576b7ee2ec9de33a3980cefd6"
 dependencies = [
  "anymap2",
- "chrono",
  "itertools",
  "kstring",
  "liquid-derive",
@@ -1048,13 +1053,14 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+ "time 0.3.9",
 ]
 
 [[package]]
 name = "liquid-derive"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510e456700da1afe07603913b0da5a2595f2482656ade07abf719aae7501f0a"
+checksum = "d82d81028aba7e869d0aa423ae926a7f15fd55ca576baac279ed38020b180a56"
 dependencies = [
  "proc-macro2",
  "proc-quote",
@@ -1063,17 +1069,17 @@ dependencies = [
 
 [[package]]
 name = "liquid-lib"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341259f779ff663bdf1fc478bddb2ca51fda25414006dc69395eddfac07e0a4"
+checksum = "8256326835eae262affdc6df8743d9e1b917354ba3c8c380e6238426a8097564"
 dependencies = [
- "chrono",
  "itertools",
  "kstring",
  "liquid-core",
  "once_cell",
  "percent-encoding",
  "regex",
+ "time 0.3.9",
  "unicode-segmentation",
 ]
 
@@ -1340,6 +1346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -2115,7 +2130,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -2127,7 +2142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -2371,6 +2386,24 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -2630,8 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -2652,8 +2685,8 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "anyhow",
  "educe",
@@ -2670,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "derive-new",
  "educe",
@@ -2681,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "cc",
  "derive-new",
@@ -2703,8 +2736,8 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2717,8 +2750,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "bytes",
  "derive-new",
@@ -2736,8 +2769,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.15.9-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.15.9-pre-range-no-fs#2035a4cf894a5016cb4a85a537d4d893dc881928"
+version = "0.16.2-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
 dependencies = [
  "educe",
  "tract-nnef",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,8 +47,8 @@ tokio-util = {git = 'https://github.com/mithril-security/tokio-sgx', tag = "toki
 tonic-rpc = {git = "https://github.com/mithril-security/tonic-rpc.git", branch = "main"}
 tower = {git = 'https://github.com/mithril-security/tower-sgx', branch = "tower-sgx"}
 tracing-core = {git = 'https://github.com/mithril-security/tracing-sgx', branch = "tracing-core-sgx"}
-tract-core = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.15.9-pre-range-no-fs"}
-tract-onnx = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.15.9-pre-range-no-fs"}
+tract-core = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.2-pre-interpolation-nearest"}
+tract-onnx = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.2-pre-interpolation-nearest"}
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 sgx_alloc = {path = "./sgx_sdk/sgx_alloc"}

--- a/server/blindai_sgx/Cargo.toml
+++ b/server/blindai_sgx/Cargo.toml
@@ -43,8 +43,8 @@ tokio-util = "=0.6.8"
 toml = "*"
 tonic = {version = "0.5.2", features = ["tls"]}
 tonic-rpc = {version = "0.1.1", features = ["json"]}
-tract-core = {version = "0.15.9-pre"}
-tract-onnx = {version = "0.15.9-pre"}
+tract-core = {version = "0.16.2-pre"}
+tract-onnx = {version = "0.16.2-pre"}
 x509-parser = "*"
 h2 = "=0.3.4"
 prost-types = "=0.8"


### PR DESCRIPTION
## Description

Upgrade to Tract version 0.16.2-pre, fix in the setup.py of the client, and pinning grpcio to 1.44.0

The setup.py of the client failed to generate the python files of the securedexchange proto files.
When calling protoc from the grpcio_tools python class, no includes are loaded. As the new version of BlindAI now uses timestamp.proto from Google, the generation failed every time. 
The setup.py now loads all includes provided by Google, making possible to generate the securedexchange python files.

Grpcio 1.45.0 was yanked on Pypi, in order to avoid any issues, the pinned Grpcio version used in BlindAI will be 1.44.0 from now on.

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.

- [x] This change affects the client
- [x] This change affects the server

## How Has This Been Tested?

The project was compiled locally, and the CI tests runned manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
