### PR TITLE
Update futures-rs

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -647,8 +647,8 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -661,8 +661,8 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -670,13 +670,13 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -685,16 +685,14 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -702,20 +700,19 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -725,8 +722,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1659,12 +1654,6 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3169,5 +3158,5 @@ version = "1.1.4"
 
 [[patch.unused]]
 name = "futures-test"
-version = "0.3.17"
-source = "git+https://github.com/mithril-security/futures-sgx?branch=futures-sgx#b526ad377d688c3bc8d733f25da655f38be0dbdb"
+version = "0.3.21"
+source = "git+https://github.com/mithril-security/futures-sgx?tag=0.3.21-sgx#147db1fd9d7005685ac86626ca9077a6f531cbc2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,16 +17,16 @@ exclude = ["sgx_sdk"]
 anyhow = {git = 'https://github.com/mithril-security/anyhow-xargo-sgx.git', tag = "1.0.45-sgx"}
 b64-ct = {git = "https://github.com/mithril-security/b64-ct.git", tag = "v0.1.1-sgx"}
 env_logger = {git = "https://github.com/mithril-security/env_logger-sgx.git", tag = "v0.9.0-sgx"}
-futures = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-channel = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-core = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-executor = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-io = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-macro = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-sink = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-task = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-test = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
-futures-util = {git = 'https://github.com/mithril-security/futures-sgx', branch = "futures-sgx"}
+futures = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-channel = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-core = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-executor = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-io = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-macro = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-sink = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-task = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-test = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
+futures-util = {git = 'https://github.com/mithril-security/futures-sgx', tag = "0.3.21-sgx"}
 h2 = {git = 'https://github.com/mithril-security/h2-sgx', branch = "h2-sgx"}
 httparse = {git = "https://github.com/mithril-security/httparse-sgx.git"}
 hyper = {git = 'https://github.com/mithril-security/hyper-sgx', tag = "v0.14.13-sgx"}


### PR DESCRIPTION
## Description

The current master branch does not seem to compile anymore from the dockerfile. This is because I updated [our fork of futures.rs](https://github.com/mithril-security/futures-sgx) today, and the cargo patch we are using on blindai is targeting the `futures-sgx` branch from the repo. Since the version from the Cargo.lock file cannot be found on the `futures-sgx` branch anymore, compilation fails.

This PR fixes this by targeting a tag (instead of a branch) from the `futures-sgx` repo. We should do this for the other patches we have, so that this sort of issue does not happen again.

I have also updated the futures-rs versions to the latest ones.

## Related Issue

None

## Type of change

- [ ] This change requires a documentation update
- [ ] This change affects the client
- [x] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

None

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation according to my changes
