### PR TITLE
server: Optimize docker image sizes

### DIFF
--- a/server/docker/build.dockerfile
+++ b/server/docker/build.dockerfile
@@ -1,27 +1,91 @@
+# Build tree:
+# base
+#  \-> base-build
+#       \-> build-software
+#       \-> build-hardware
+#  \-> software
+#       * copies binaries from build-software
+#  \-> hardware
+#       * copies binaries from build-hardware
+#  \-> hardware-dcsv3
+#       * copies binaries from build-hardware
+#
+# Check <https://docs.mithrilsecurity.io/started/installation> for more info
+
 #######################################
 ### Base stage: common dependencies ###
 #######################################
+
+### base: This image is kept minimal and optimized for size. It has the common runtime dependencies
 FROM ubuntu:18.04 AS base
 
-ENV CODENAME=bionic
-ENV UBUNTU_VERSION=18.04
-ENV VERSION=2.15.101.1-bionic1
-ENV DCAP_VERSION=1.12.101.1-bionic1
-ENV SGX_LINUX_X64_SDK=sgx_linux_x64_sdk_2.15.101.1.bin
-ENV SGX_LINUX_X64_SDK_URL="https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu18.04-server/"$SGX_LINUX_X64_SDK
-ENV SGX_DCAP_PCCS_VERSION=1.3.101.3-bionic1
-ENV GCC_VERSION=8.4.0-1ubuntu1~18.04
-ENV RUST_TOOLCHAIN=nightly-2021-11-01
-ENV RUST_UNTRUSTED_TOOLCHAIN=nightly-2021-11-01
-ENV DCAP_PRIMITIVES_VERSION=DCAP_1.12.1
-ENV DCAP_PRIMITIVES_COMMIT=4b2b8fcef71caa4da294e2171b3816e2baa3ceaf
+ARG CODENAME=bionic
+ARG UBUNTU_VERSION=18.04
+ARG SGX_VERSION=2.15.101.1-bionic1
+ARG DCAP_VERSION=1.12.101.1-bionic1
+ARG SGX_LINUX_X64_SDK=sgx_linux_x64_sdk_2.15.101.1.bin
+ARG SGX_LINUX_X64_SDK_URL="https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu18.04-server/"$SGX_LINUX_X64_SDK
 
-# -- setup
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /root
 
-# dependencies that will be removed after build
-ENV BUILD_ONLY_DEPS \
+# -- Install SGX SDK & SGX drivers
+RUN \
+    # Install temp dependencies
+    TEMP_DEPENDENCIES="wget gnupg curl software-properties-common build-essential make" && \
+    apt-get update -y && apt-get install -y $TEMP_DEPENDENCIES && \
+
+    # Intall the SGX drivers
+    curl -fsSL  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
+    add-apt-repository "deb https://download.01.org/intel-sgx/sgx_repo/ubuntu $CODENAME main" && \
+    apt-get install -y \
+        sgx-aesm-service=$SGX_VERSION \
+        libsgx-ae-epid=$SGX_VERSION \
+        libsgx-ae-le=$SGX_VERSION \
+        libsgx-ae-pce=$SGX_VERSION \
+        libsgx-aesm-ecdsa-plugin=$SGX_VERSION \
+        libsgx-aesm-epid-plugin=$SGX_VERSION \
+        libsgx-aesm-launch-plugin=$SGX_VERSION \
+        libsgx-aesm-pce-plugin=$SGX_VERSION \
+        libsgx-aesm-quote-ex-plugin=$SGX_VERSION \
+        libsgx-enclave-common=$SGX_VERSION \
+        libsgx-epid=$SGX_VERSION \
+        libsgx-launch=$SGX_VERSION \
+        libsgx-quote-ex=$SGX_VERSION \
+        libsgx-uae-service=$SGX_VERSION \
+        libsgx-urts=$SGX_VERSION \
+        libsgx-ae-qe3=$DCAP_VERSION \
+        libsgx-ae-pce=$SGX_VERSION \
+        libsgx-pce-logic=$DCAP_VERSION \
+        libsgx-qe3-logic=$DCAP_VERSION \
+        libsgx-ra-network=$DCAP_VERSION \
+        libsgx-ra-uefi=$DCAP_VERSION \
+        libsgx-dcap-ql=$DCAP_VERSION \
+        libsgx-dcap-quote-verify=$DCAP_VERSION \
+        libsgx-dcap-default-qpl=$DCAP_VERSION && \
+    ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so && \
+
+    # Intall the SGX SDK
+    wget "https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu18.04-server/"$SGX_LINUX_X64_SDK && \
+    chmod u+x $SGX_LINUX_X64_SDK  && \
+    echo -e 'no\n/opt' | ./$SGX_LINUX_X64_SDK && \
+    rm $SGX_LINUX_X64_SDK && \
+    echo 'source /opt/sgxsdk/environment' >> /etc/environment && \
+
+    # Remove temp dependencies
+    apt-get remove -y $TEMP_DEPENDENCIES && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/archives/*
+
+ENV LD_LIBRARY_PATH=/opt/sgxsdk/sdk_libs:/usr/lib:/usr/local/lib:/opt/intel/sgx-aesm-service/aesm/
+
+### base-build: This image has the common build-time dependencies
+FROM base AS base-build
+
+ENV GCC_VERSION=8.4.0-1ubuntu1~18.04
+ENV RUST_TOOLCHAIN=nightly-2021-11-01
+ENV RUST_UNTRUSTED_TOOLCHAIN=nightly-2021-11-01
+
+RUN apt update && apt install -y \
     unzip \
     lsb-release \
     debhelper \
@@ -59,61 +123,18 @@ ENV BUILD_ONLY_DEPS \
     uuid-dev \
     wget \
     zip \
-    software-properties-common
-
-RUN apt update && apt install -y \
-    $BUILD_ONLY_DEPS \
-    # dependencies that should be kept after build
+    software-properties-common \
     cracklib-runtime \
     gcc-8=$GCC_VERSION
 
-# -- custom binutils
+# -- Custom binutils
 RUN cd /root && \
     wget https://download.01.org/intel-sgx/sgx-linux/2.15.1/as.ld.objdump.r4.tar.gz && \
     tar xzf as.ld.objdump.r4.tar.gz && \
     cp -r external/toolset/$BINUTILS_DIST/* /usr/bin/ && \
     rm -rf ./external ./as.ld.objdump.r4.tar.gz
 
-# -- sgx sdk
-RUN wget $SGX_LINUX_X64_SDK_URL               && \
-    chmod u+x $SGX_LINUX_X64_SDK              && \
-    echo -e 'no\n/opt' | ./$SGX_LINUX_X64_SDK && \
-    rm $SGX_LINUX_X64_SDK                     && \
-    echo 'source /opt/sgxsdk/environment' >> /etc/environment
-ENV LD_LIBRARY_PATH=/opt/sgxsdk/sdk_libs:/usr/lib:/usr/local/lib:/opt/intel/sgx-aesm-service/aesm/
-
-# -- libsgx
-RUN curl -fsSL  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
-    add-apt-repository "deb https://download.01.org/intel-sgx/sgx_repo/ubuntu $CODENAME main" && \
-    apt-get install -y \
-        sgx-aesm-service=$VERSION \
-        libsgx-ae-epid=$VERSION \
-        libsgx-ae-le=$VERSION \
-        libsgx-ae-pce=$VERSION \
-        libsgx-aesm-ecdsa-plugin=$VERSION \
-        libsgx-aesm-epid-plugin=$VERSION \
-        libsgx-aesm-launch-plugin=$VERSION \
-        libsgx-aesm-pce-plugin=$VERSION \
-        libsgx-aesm-quote-ex-plugin=$VERSION \
-        libsgx-enclave-common=$VERSION \
-        libsgx-epid=$VERSION \
-        libsgx-launch=$VERSION \
-        libsgx-quote-ex=$VERSION \
-        libsgx-uae-service=$VERSION \
-        libsgx-urts=$VERSION \
-        libsgx-ae-qe3=$DCAP_VERSION \
-        libsgx-ae-pce=$VERSION \
-        libsgx-pce-logic=$DCAP_VERSION \
-        libsgx-qe3-logic=$DCAP_VERSION \
-        libsgx-ra-network=$DCAP_VERSION \
-        libsgx-ra-uefi=$DCAP_VERSION \
-        libsgx-dcap-ql=$DCAP_VERSION \
-        libsgx-dcap-quote-verify=$DCAP_VERSION \
-        libsgx-dcap-default-qpl=$DCAP_VERSION && \
-    mkdir -p /var/run/aesmd && \
-    ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
-
-# -- rust
+# -- Rust
 RUN cd /root && \
     curl 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init' --output /root/rustup-init && \
     chmod +x /root/rustup-init && \
@@ -129,15 +150,44 @@ ENV PATH="/root/.cargo/bin:$PATH"
 ##################################
 ### Hardware (production) mode ###
 ##################################
-FROM base AS build-hardware
 
-# -- nodejs (needed for pccs)
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g esm pm2
+### build-hardware: This image is used for building the app
+FROM base-build AS build-hardware
 
-# -- dcap pccs
-RUN git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b "$DCAP_PRIMITIVES_VERSION" --depth 1 && \
+COPY . ./server
+
+ENV SGX_MODE=HW
+
+RUN --mount=type=cache,target=/root/server/target \
+    --mount=type=cache,target=/root/server/tmp \
+    --mount=type=cache,target=/root/.xargo \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/root/.cargo/registry \
+    make -C server SGX_MODE=HW all bin/tls/host_server.pem bin/tls/host_server.key && \
+    cp -r ./server/bin/* /root && \
+    cp ./server/policy.toml /root/policy.toml
+
+### hardware: This image is used for running the app. It is kept minimal and optimized for size
+FROM base AS hardware
+
+ARG DCAP_PRIMITIVES_VERSION=DCAP_1.12.1
+ARG DCAP_PRIMITIVES_COMMIT=4b2b8fcef71caa4da294e2171b3816e2baa3ceaf
+ARG SGX_DCAP_PCCS_VERSION=1.3.101.3-bionic1
+
+# -- Install DCAP PCCS
+RUN \
+    --mount=type=bind,source=docker/setup-pccs.sh,target=/root/setup-pccs.sh \
+
+    # Install temp dependencies
+    TEMP_DEPENDENCIES="git curl make build-essential gcc g++" && \
+    apt-get update -y && apt-get install -y $TEMP_DEPENDENCIES && \
+
+    # Install nodejs (needed for PCCS)
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs cracklib-runtime && \
+
+    # Install DCAP PCCS
+    git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b "$DCAP_PRIMITIVES_VERSION" --depth 1 && \
     # assert commit hash
     test "$(git -C SGXDataCenterAttestationPrimitives rev-parse HEAD)" = "$DCAP_PRIMITIVES_COMMIT" && \
     make -C SGXDataCenterAttestationPrimitives/tools/PCKCertSelection/ && \
@@ -145,101 +195,93 @@ RUN git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b
     cp SGXDataCenterAttestationPrimitives/tools/PCKCertSelection/out/libPCKCertSelection.so SGXDataCenterAttestationPrimitives/QuoteGeneration/pccs/lib/ && \
     cp -R SGXDataCenterAttestationPrimitives/QuoteGeneration/pccs/ /opt/intel/sgx-dcap-pccs && \
     rm -rf SGXDataCenterAttestationPrimitives && \
-    apt-get install -y libsgx-dcap-pccs=$SGX_DCAP_PCCS_VERSION
+    apt-get install -y libsgx-dcap-pccs=$SGX_DCAP_PCCS_VERSION && \
 
-ADD docker/setup-pccs.sh /root
-RUN /root/setup-pccs.sh && \
-    rm setup-pccs.sh && \
-    sed -i 's/#USE_SECURE_CERT=FALSE/USE_SECURE_CERT=FALSE/g' /etc/sgx_default_qcnl.conf
+    # Install needed nodejs packages
+    npm install -g esm pm2 && \
+    sed -i 's/#USE_SECURE_CERT=FALSE/USE_SECURE_CERT=FALSE/g' /etc/sgx_default_qcnl.conf && \
 
-# -- build
-COPY . ./server
+    # Run setup script
+    /root/setup-pccs.sh && \
 
-RUN --mount=type=cache,target=/root/server/target \
-    --mount=type=cache,target=/root/server/tmp \
-    --mount=type=cache,target=/root/.xargo \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/root/.cargo/registry \
-    make -C server SGX_MODE=HW all bin/tls/host_server.pem bin/tls/host_server.key && \
-    cp -r ./server/bin/* /root && \
-    cp ./server/policy.toml /root/policy.toml
+    # Remove temp dependencies
+    apt-get remove -y $TEMP_DEPENDENCIES && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/archives/*
 
-## final image
-FROM build-hardware AS hardware
+COPY docker/hardware-start.sh /root/start.sh
 
-# -- cleanup
-RUN rustup self uninstall -y && \
-    rm -rf .npm .xargo .wget-hsts && \
-    apt-get remove -y $BUILD_ONLY_DEPS && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/archives/* && \
-    (rm -rf ./server || true)
-
-ADD docker/hardware-start.sh /root/start.sh
+# -- Copy built files from the build image
+COPY --from=build-hardware \
+    /root/enclave.signed.so \
+    /root/blindai_app \
+    /root/config.toml \
+    /root/policy.toml \
+    /root
+COPY --from=build-hardware \
+    /root/tls/ \
+    /root/tls/
 
 EXPOSE 50052
 EXPOSE 50051
 
-CMD ["/root/start.sh"]
+CMD ./start.sh
 
 #################################################
 ### Hardware (production) mode - Azure DCs_v3 ###
 #################################################
-FROM base AS build-hardware-dcsv3
 
-# -- flag Azure DCs_v3 mode
-ENV BLINDAI_AZURE_DCSV3_PATCH=1
+### hardware-dcsv3: This image is used for running the app. It is kept minimal and optimized for size
+FROM base AS hardware-dcsv3
 
-# -- install azure_dcap_client, but we need to remove the default 
-# -- quote providing library in order to avoid conflicts
-RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    add-apt-repository "https://packages.microsoft.com/ubuntu/"$UBUNTU_VERSION"/prod" && \
-    apt-get update && \
+# -- Install azure_dcap_client
+RUN \
+    # Install temp dependencies
+    TEMP_DEPENDENCIES="curl gnupg software-properties-common" && \
+    apt-get update -y && apt-get install -y $TEMP_DEPENDENCIES && \
+
+    # We need to remove the default quote providing library in order to avoid conflicts
     apt-get remove -y libsgx-dcap-default-qpl && \
-    apt-get install -y az-dcap-client && \
-    ln -s /usr/lib/libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
+    
+    # Install azure_dcap_client
+    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    add-apt-repository "https://packages.microsoft.com/ubuntu/"$UBUNTU_VERSION"/prod" && \
+    apt-get update && apt-get install -y az-dcap-client && \
+    ln -s /usr/lib/libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 && \
 
-# -- build
-COPY . ./server
+    # Remove temp dependencies
+    apt-get remove -y $TEMP_DEPENDENCIES && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/archives/*
 
-RUN --mount=type=cache,target=/root/server/target \
-    --mount=type=cache,target=/root/server/tmp \
-    --mount=type=cache,target=/root/.xargo \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/root/.cargo/registry \
-    make -C server SGX_MODE=HW all bin/tls/host_server.pem bin/tls/host_server.key && \
-    cp -r ./server/bin/* /root && \
-    cp ./server/policy.toml /root/policy.toml
+COPY docker/hardware-dcsv3.sh /root/start.sh
 
-## final image
-FROM build-hardware-dcsv3 AS hardware-dcsv3
+# -- Copy built files from the build image
+COPY --from=build-hardware \
+    /root/enclave.signed.so \
+    /root/blindai_app \
+    /root/config.toml \
+    /root/policy.toml \
+    /root
+COPY --from=build-hardware \
+    /root/tls/ \
+    /root/tls/
 
-# -- cleanup
-RUN rustup self uninstall -y && \
-    rm -rf .npm .xargo .wget-hsts && \
-    apt-get remove -y $BUILD_ONLY_DEPS && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/archives/* && \
-    (rm -rf ./server || true)
-
-ADD docker/hardware-dcsv3.sh /root/start.sh
+# -- Flag Azure DCs_v3 mode
+ENV BLINDAI_AZURE_DCSV3_PATCH=1
 
 EXPOSE 50052
 EXPOSE 50051
 
-CMD ["/root/start.sh"]
+CMD ./start.sh
 
 ##################################
 ### Software (simulation) mode ###
 ##################################
-FROM base AS build-software
 
-# -- build
+### build-software: This image is used for building the app
+FROM base-build AS build-software
+
 COPY . ./server
 
-# -- flag software mode
 ENV SGX_MODE=SW
 
 RUN --mount=type=cache,target=/root/server/target \
@@ -251,22 +293,24 @@ RUN --mount=type=cache,target=/root/server/target \
     cp -r ./server/bin/* /root && \
     cp ./server/policy.toml /root/policy.toml
 
-# -- cleanup
-RUN rustup self uninstall -y && \
-    rm -rf .npm .xargo .wget-hsts && \
-    apt-get remove -y $BUILD_ONLY_DEPS && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/archives/* && \
-    (rm -rf ./server || true)
+### software: This image is used for running the app. It is kept minimal and optimized for size
+FROM base AS software
 
-## final image
-FROM build-software AS software
+# -- Copy built files from the build image
+COPY --from=build-software \
+    /root/enclave.signed.so \
+    /root/blindai_app \
+    /root/config.toml \
+    /root/policy.toml \
+    /root
+COPY --from=build-software \
+    /root/tls/ \
+    /root/tls/
 
-ADD docker/software-start.sh /root/start.sh
+ENV SGX_MODE=SW
 
 EXPOSE 50052
 EXPOSE 50051
 
-CMD ["/root/start.sh"]
+CMD ./blindai_app
 

--- a/server/docker/build.dockerfile
+++ b/server/docker/build.dockerfile
@@ -63,6 +63,7 @@ RUN \
         libsgx-dcap-ql=$DCAP_VERSION \
         libsgx-dcap-quote-verify=$DCAP_VERSION \
         libsgx-dcap-default-qpl=$DCAP_VERSION && \
+    mkdir -p /var/run/aesmd && \
     ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so && \
 
     # Intall the SGX SDK

--- a/server/docker/software-start.sh
+++ b/server/docker/software-start.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd /root
-./blindai_app


### PR DESCRIPTION
## Description

On dockerhub, the images are very very big:
```
software => 852.76 MB
hardware => 929MB
hardware-dcsv3 => 853.85 MB
```
This is the compressed size, meaning the actual sizes are even bigger

Result of `docker images <image> --format "{{.Size}}"` currently (uncompressed size)
```
software => 2.96GB
hardware => 3.17GB
hardware-dcsv3 => 2.98GB
```

This pull request changes the uncompressed sizes to:
```
software => 281MB
hardware => 532MB (still big, it contains nodejs..)
hardware-dcsv3 => 286MB
```
I don't have the numbers for the compressed sizes

### How is that possible?

Docker works on an overlay filesystem. This means, every time we use an instruction such as `RUN` during the build, it will create a new filesystem layer. The final image is just every layer overlapped on one another.
This means that if we install a temporary dependency in a `RUN` command, we have to uninstall it in the same `RUN` command, or else, it will still impact the image size after being uninstalled.

The way this new Dockerfile works is by creating separate images for building the app and running it.
Build images are quite big since they have all the build dependencies, and run images are as slim as possible, and optimized for size.

### Docs: Developer environment

This PR introduces a `base-build` stage/image that has almost everything you need for developing on BlindAI server.
This is a good opportunity to document how to create a proper dev environment for the server on the docs, using docker and vscode.

Something like
```
DOCKER_BUILDKIT=1 docker build \
  -f ./server/docker/build.dockerfile \
  -t blindai-dev-env \
  --target base-build \
  --name blindai-dev-env \
  --volume $(pwd):/blindai \
#  --device /dev/sgx/enclave \
#  --device /dev/sgx/provision \
  ./server
```

What do you think? Where in the docs would that fit?

## Related Issue

None

## Type of change

- [ ] This change requires a documentation update
- [ ] This change affects the client
- [x] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

This has been tested in software mode on my machine.
The images compile fine in hardware and hardware-dcsv3 mode, but I will need to test on actual machines to make sure I did not break anything (CI doesn't check hardware and hardware-dcsv3 yet)

**This PR is marked as draft until I do these tests.**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation according to my changes
