### PR TITLE
tests: Fix running tests in the CI

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -3,8 +3,9 @@ import subprocess
 import os
 import sys
 import socket
-from time import time as now
+from time import time as now, sleep
 import shutil
+import atexit
 
 server_process = None
 policy_file = os.path.join(os.path.dirname(__file__), "policy.toml")
@@ -16,52 +17,55 @@ has_hardware_support = os.getenv("BLINDAI_TEST_NO_HW") is None
 def launch_server():
     global server_process
 
+    sock = None
+
     try:
-        if os.getenv("BLINDAI_TEST_NO_LAUNCH_SERVER") is not None:
-            return
-        if server_process is not None:
-            return
+        if server_process is None and os.getenv("BLINDAI_TEST_NO_LAUNCH_SERVER") is None:
+            server_dir = os.path.join(os.path.dirname(__file__), "../server")
+            bin_dir = os.path.join(server_dir, "bin")
 
-        server_dir = os.path.join(os.path.dirname(__file__), "../server")
-        bin_dir = os.path.join(server_dir, "bin")
+            server_process = subprocess.Popen(
+                ["./blindai_app"],
+                executable=os.path.join(bin_dir, "blindai_app"),
+                cwd=bin_dir,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                stdin=subprocess.DEVNULL,
+                env={**os.environ, "BLINDAI_DISABLE_TELEMETRY": "true"},
+            )
 
-        server_process = subprocess.Popen(
-            ["./blindai_app"],
-            executable=os.path.join(bin_dir, "blindai_app"),
-            cwd=bin_dir,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            stdin=subprocess.DEVNULL,
-            env={**os.environ, "BLINDAI_DISABLE_TELEMETRY": "true"},
-        )
-
-        shutil.copyfile(os.path.join(server_dir, "policy.toml"), policy_file)
-        shutil.copyfile(os.path.join(server_dir, "host_server.pem"), certificate_file)
+            shutil.copyfile(os.path.join(server_dir, "policy.toml"), policy_file)
+            shutil.copyfile(os.path.join(server_dir, "host_server.pem"), certificate_file)
 
         # block until server ready (port open)
-        end = now() + 5000  # 5s timeout
+        end = now() + 30 # 30s timeout
+        success = False
         while True:
             if now() > end:
-                raise Exception("server startup timed out")
+                raise Exception("Server startup timed out")
 
             try:
-                s = socket.socket()
-                s.settimeout(end - now())
-                s.connect(("localhost", 50053))
+                sock = socket.socket()
+                sock.settimeout(end - now())
+                sock.connect(("localhost", 50052))
+                success = True
+                sock.close()
+                break
             except socket.error as err:
                 if err.errno != errno.ECONNREFUSED:
-                    s.close()
-                    server_process.terminate()
-                    server_process.wait()
                     raise
-                s.close()
-            else:
-                s.close()
-                break
+                sock.close()
+                sleep(0.1)
 
-        print("Server started")
+        if not success:
+            raise Exception("Server startup timed out")
+
+        print("[TESTS] The server is running")
 
     except:
+        if sock is not None:
+            sock.close()
+
         if server_process is not None:
             server_process.terminate()
             server_process.wait()
@@ -78,4 +82,7 @@ def close_server():
     server_process.wait()
     server_process = None
 
-    print("Server stopped")
+    print("[TESTS] The server is stopped")
+
+
+atexit.register(close_server)

--- a/tests/test_covidnet.py
+++ b/tests/test_covidnet.py
@@ -2,7 +2,6 @@ from blindai.client import BlindAiClient, ModelDatumType
 import unittest
 from server import (
     launch_server,
-    close_server,
     policy_file,
     certificate_file,
     has_hardware_support,
@@ -31,10 +30,14 @@ class TestCovidNetBase:
         model = os.path.join(os.path.dirname(__file__), "assets/COVID-Net-CXR-2.onnx")
 
         client.upload_model(
-            model=model, shape=(1, 480, 480, 3), dtype=ModelDatumType.F32,
+            model=model,
+            shape=(1, 480, 480, 3),
+            dtype=ModelDatumType.F32,
         )
 
-        response = client.run_model(flattened_img,)
+        response = client.run_model(
+            flattened_img,
+        )
 
         ort_session = onnxruntime.InferenceSession(model)
         ort_inputs = {ort_session.get_inputs()[0].name: img}
@@ -85,10 +88,6 @@ def setUpModule():
     img = img[np.newaxis, :, :, :]
 
     flattened_img = img.flatten().tolist()
-
-
-def tearDownModule():
-    close_server()
 
 
 if __name__ == "__main__":

--- a/tests/test_distilbert.py
+++ b/tests/test_distilbert.py
@@ -6,7 +6,6 @@ import unittest
 import os
 from server import (
     launch_server,
-    close_server,
     policy_file,
     certificate_file,
     has_hardware_support,
@@ -31,7 +30,9 @@ class TestDistilBertBase:
         )
 
         client.upload_model(
-            model=model_path, shape=inputs.shape, dtype=ModelDatumType.I64,
+            model=model_path,
+            shape=inputs.shape,
+            dtype=ModelDatumType.I64,
         )
 
         response = client.run_model(run_inputs)
@@ -112,10 +113,6 @@ def setUpModule():
     )
 
     run_inputs = tokenizer(sentence, padding="max_length", max_length=8)["input_ids"]
-
-
-def tearDownModule():
-    close_server()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Sometimes, the tests don't work in the CI. This is because there are no checks on whether the server has got time to launch properly if  `BLINDAI_TEST_NO_LAUNCH_SERVER` is set (this env var is set on the CI because the CI launches the server itself, using docker)
This caused the tests to sometimes run before the app was running.

I have also changed some other things, such as adding a bit of `sleep`, fixing the timeout (which, turns out, wasn't really working) and checking for the right port. The tests should be much much more reliable now on the CI.

## Related Issue

None

## Type of change

- [ ] This change requires a documentation update
- [ ] This change affects the client
- [ ] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

Run the CI, and run the tests locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation according to my changes
