### PR TITLE
add python and rust pre-commit lint/formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 89
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    - id: fmt
+      args: ['--all','--manifest-path','server/Cargo.toml', '--verbose', '--'] 

--- a/client/blindai/client.py
+++ b/client/blindai/client.py
@@ -245,7 +245,7 @@ class BlindAiClient:
             UploadModelResponse object, containing one field:
                 proof: optional, a ProofData object with two fields:
                     payload: the payload returned by the server
-                    signature: the signature returned by the server 
+                    signature: the signature returned by the server
         Raises:
             ConnectionError: will be raised if the connection with the server fails.
             FileNotFoundError: will be raised if the model file is not found.

--- a/client/blindai/utils/errors.py
+++ b/client/blindai/utils/errors.py
@@ -28,7 +28,7 @@ def check_socket_exception(socket_error):
         return f"Failed To connect to the server due to Socket error : message={error_message}"
 
     else:
-        return f"Failed To connect to the server due to Socket error "
+        return "Failed To connect to the server due to Socket error "
 
 
 class SignatureError(Exception):

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,3 +4,20 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.cibuildwheel]
 skip = "pp*"
+
+[tool.black]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.env
+  | _build
+  | buck-out
+  | build
+  | dist
+  | blindai.egg-info
+  | third_party
+)/
+'''

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -12,3 +12,4 @@ patchelf
 check-wheel-contents
 auditwheel
 cibuildwheel
+pre-commit

--- a/client/setup.py
+++ b/client/setup.py
@@ -48,8 +48,8 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
-            f"-DBUILD_TESTS=false",
-            f"-DBUILD_ATTESTATION_APP=false",
+            "-DBUILD_TESTS=false",
+            "-DBUILD_ATTESTATION_APP=false",
         ]
 
         build_args = []

--- a/tests/server.py
+++ b/tests/server.py
@@ -20,7 +20,10 @@ def launch_server():
     sock = None
 
     try:
-        if server_process is None and os.getenv("BLINDAI_TEST_NO_LAUNCH_SERVER") is None:
+        if (
+            server_process is None
+            and os.getenv("BLINDAI_TEST_NO_LAUNCH_SERVER") is None
+        ):
             server_dir = os.path.join(os.path.dirname(__file__), "../server")
             bin_dir = os.path.join(server_dir, "bin")
 
@@ -35,10 +38,12 @@ def launch_server():
             )
 
             shutil.copyfile(os.path.join(server_dir, "policy.toml"), policy_file)
-            shutil.copyfile(os.path.join(server_dir, "host_server.pem"), certificate_file)
+            shutil.copyfile(
+                os.path.join(server_dir, "host_server.pem"), certificate_file
+            )
 
         # block until server ready (port open)
-        end = now() + 30 # 30s timeout
+        end = now() + 30  # 30s timeout
         success = False
         while True:
             if now() > end:
@@ -62,7 +67,7 @@ def launch_server():
 
         print("[TESTS] The server is running")
 
-    except:
+    except Exception:
         if sock is not None:
             sock.close()
 


### PR DESCRIPTION
## Description
Use pre-commit hooks, to apply python lint/formatting and rust formatting automatically before making commits. 
Only once, when cloning the repo / pulling these changes, it's needed to install pre-commit:
```bash
pip install pre-commit
```
and run:
```
pre-commit install
```
## Related Issue
None.

## Type of change
Not affecting the existing codebase.

## How Has This Been Tested?
On some test commits.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

