### PR TITLE
add configurable ports to client

### DIFF
--- a/client/CHANGELOG
+++ b/client/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] ## 2022-03-25
 ### Added
+- Configurable ports. 
 - Support receiving and verifiying signed responses from the server.
 - Request the the version of the server when initiating a connextion and raise an exception if the returned version is not supported.  
 

--- a/client/blindai/client.py
+++ b/client/blindai/client.py
@@ -104,8 +104,8 @@ class BlindAiClient:
         policy: str = "",
         certificate: str = "",
         simulation: bool = False,
-        unsigned_port: str = "50052",
-        signed_port: str = "50051",
+        untrusted_port: int = 50052,
+        attested_port: int = 50051,
     ):
         """Connect to the server with the specified parameters.
         You will have to specify here the expected policy (server identity, configuration...)
@@ -124,8 +124,8 @@ class BlindAiClient:
                 Generated in the server side.
             simulation:  Connect to the server in simulation mode (default False).
                 If set to True, the args policy and certificate will be ignored.
-            unsigned_port: unsigned connection server port, default 50052
-            signed_port: signed connection server port, dedault 50051
+            untrusted_port: untrusted connection server port, default 50052
+            attested_port: attested connection server port, dedault 50051
         Raises:
             VersionError: Will be raised if the version of the server is not supported by the client.
             ValueError: Will be raised in case the policy doesn't match the
@@ -140,8 +140,8 @@ class BlindAiClient:
 
         addr = strip_https(addr)
 
-        untrusted_client_to_enclave = addr + ":" + unsigned_port
-        attested_client_to_enclave = addr + ":" + signed_port
+        untrusted_client_to_enclave = addr + ":" + str(untrusted_port)
+        attested_client_to_enclave = addr + ":" + str(attested_port)
 
         if self.DISABLE_UNTRUSTED_SERVER_CERT_CHECK:
             logging.warning("Untrusted server certificate check bypassed")
@@ -149,7 +149,7 @@ class BlindAiClient:
             try:
                 socket.setdefaulttimeout(CONNECTION_TIMEOUT)
                 untrusted_server_cert = ssl.get_server_certificate(
-                    (addr, int(unsigned_port))
+                    (addr, untrusted_port)
                 )
                 untrusted_server_creds = ssl_channel_credentials(
                     root_certificates=bytes(untrusted_server_cert, encoding="utf8")

--- a/client/blindai/client.py
+++ b/client/blindai/client.py
@@ -61,7 +61,6 @@ from utils.errors import (
     VersionError,
 )
 
-PORTS = {"untrusted_enclave": "50052", "attested_enclave": "50051"}
 CONNECTION_TIMEOUT = 10
 
 ModelDatumType = IntEnum("ModelDatumType", DatumTypeEnum.items())
@@ -105,6 +104,8 @@ class BlindAiClient:
         policy: str = "",
         certificate: str = "",
         simulation: bool = False,
+        unsigned_port: str = "50052",
+        signed_port: str = "50051",
     ):
         """Connect to the server with the specified parameters.
         You will have to specify here the expected policy (server identity, configuration...)
@@ -123,7 +124,8 @@ class BlindAiClient:
                 Generated in the server side.
             simulation:  Connect to the server in simulation mode (default False).
                 If set to True, the args policy and certificate will be ignored.
-
+            unsigned_port: unsigned connection server port, default 50052
+            signed_port: signed connection server port, dedault 50051
         Raises:
             VersionError: Will be raised if the version of the server is not supported by the client.
             ValueError: Will be raised in case the policy doesn't match the
@@ -138,8 +140,8 @@ class BlindAiClient:
 
         addr = strip_https(addr)
 
-        untrusted_client_to_enclave = addr + ":" + PORTS["untrusted_enclave"]
-        attested_client_to_enclave = addr + ":" + PORTS["attested_enclave"]
+        untrusted_client_to_enclave = addr + ":" + unsigned_port
+        attested_client_to_enclave = addr + ":" + signed_port
 
         if self.DISABLE_UNTRUSTED_SERVER_CERT_CHECK:
             logging.warning("Untrusted server certificate check bypassed")
@@ -147,7 +149,7 @@ class BlindAiClient:
             try:
                 socket.setdefaulttimeout(CONNECTION_TIMEOUT)
                 untrusted_server_cert = ssl.get_server_certificate(
-                    (addr, int(PORTS["untrusted_enclave"]))
+                    (addr, int(unsigned_port))
                 )
                 untrusted_server_creds = ssl_channel_credentials(
                     root_certificates=bytes(untrusted_server_cert, encoding="utf8")


### PR DESCRIPTION
## Description
Configurable ports numbers in the client side.
## Related PR
Following up with #35 which was accidentally closed
## Type of change
- [X] This change requires a documentation update
- [X] This change affects the client
- [X] This change affects the API (The client interface, not the proto) 

## How Has This Been Tested?

Tested locally with default and custom ports numbers. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have updated the documentation according to my changes (The changelog file)
