### PR TITLE
now supports custom output types

### DIFF
--- a/client/proto/securedexchange.proto
+++ b/client/proto/securedexchange.proto
@@ -65,6 +65,7 @@ message SendModelRequest {
     ClientInfo client_info = 6;
     // this is optional
     string model_name = 7;
+    DatumTypeEnum datum_output = 8;
 }
 
 enum DatumTypeEnum {
@@ -82,6 +83,7 @@ message SendModelReply {
     // Signature of the payload
     // This field is not present when `sign` is `false` in the request
     bytes signature = 2;
+
 }
 
 message SendModelPayload {
@@ -112,8 +114,9 @@ message RunModelReply {
 }
 
 message RunModelPayload {
-    repeated float output = 1;
+    bytes output = 1;
+    DatumTypeEnum datum_output = 2;
     // Raw SHA-256 hash of the protobuf binary encoding of the repeated float input from RunModelRequest
     // This field is empty when `sign` is `false` in the request
-    bytes input_hash = 2;
+    bytes input_hash = 3;
 }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2652,8 +2652,8 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -2674,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "anyhow",
  "educe",
@@ -2692,8 +2692,8 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "derive-new",
  "educe",
@@ -2703,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "cc",
  "derive-new",
@@ -2725,8 +2725,8 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2739,8 +2739,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "bytes",
  "derive-new",
@@ -2758,8 +2758,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.16.2-pre"
-source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.2-pre-interpolation-nearest#51e2f9680c2403fc589638f09536227e0d00a6dd"
+version = "0.16.6-pre"
+source = "git+https://github.com/mithril-security/tract-sgx-xargo.git?tag=0.16.6-pre-interpolation-nearest#6cb21e97ccde2921db4838346463355a4f6a9815"
 dependencies = [
  "educe",
  "tract-nnef",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,8 +47,8 @@ tokio-util = {git = 'https://github.com/mithril-security/tokio-sgx', tag = "toki
 tonic-rpc = {git = "https://github.com/mithril-security/tonic-rpc.git", branch = "main"}
 tower = {git = 'https://github.com/mithril-security/tower-sgx', branch = "tower-sgx"}
 tracing-core = {git = 'https://github.com/mithril-security/tracing-sgx', branch = "tracing-core-sgx"}
-tract-core = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.2-pre-interpolation-nearest"}
-tract-onnx = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.2-pre-interpolation-nearest"}
+tract-core = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.6-pre-interpolation-nearest"}
+tract-onnx = {git = "https://github.com/mithril-security/tract-sgx-xargo.git", tag = "0.16.6-pre-interpolation-nearest"}
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 sgx_alloc = {path = "./sgx_sdk/sgx_alloc"}

--- a/server/blindai_sgx/Cargo.toml
+++ b/server/blindai_sgx/Cargo.toml
@@ -43,8 +43,8 @@ tokio-util = "=0.6.8"
 toml = "*"
 tonic = {version = "0.5.2", features = ["tls"]}
 tonic-rpc = {version = "0.1.1", features = ["json"]}
-tract-core = {version = "0.16.2-pre"}
-tract-onnx = {version = "0.16.2-pre"}
+tract-core = {version = "0.16.6-pre"}
+tract-onnx = {version = "0.16.6-pre"}
 x509-parser = "*"
 h2 = "=0.3.4"
 prost-types = "=0.8"

--- a/server/proto/securedexchange.proto
+++ b/server/proto/securedexchange.proto
@@ -65,6 +65,7 @@ message SendModelRequest {
     ClientInfo client_info = 6;
     // this is optional
     string model_name = 7;
+    DatumTypeEnum datum_output = 8;
 }
 
 enum DatumTypeEnum {
@@ -112,8 +113,9 @@ message RunModelReply {
 }
 
 message RunModelPayload {
-    repeated float output = 1;
+    bytes output = 1;
+    DatumTypeEnum datum_output = 2;
     // Raw SHA-256 hash of the protobuf binary encoding of the repeated float input from RunModelRequest
     // This field is empty when `sign` is `false` in the request
-    bytes input_hash = 2;
+    bytes input_hash = 3;
 }


### PR DESCRIPTION
## Description

Output format now customizable
The output format was forced to float32 until now. This can now be changed from the client, with a new parameter in upload model named dtype_out, using the enum ModelDatumType.

## Related Issue

#54 

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.
 
- [x] This change requires a documentation update
- [x] This change affects the client
- [x] This change affects the server
- [x] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

CI tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation according to my changes