### PR TITLE
Client build for macOS (x64) platforms

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,7 +8,7 @@ link_directories(blindai/lib)
 add_subdirectory(third_party/pybind11)
 pybind11_add_module(_quote_verification blindai/cpp/wrapper.cc)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(_quote_verification 
     PRIVATE verify
     PRIVATE QuoteVerification

--- a/client/scripts/buildAttestationLibDarwin.sh
+++ b/client/scripts/buildAttestationLibDarwin.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cd blindai
+
+mkdir lib
+
+cd ../third_party/attestationLib
+
+mkdir build
+
+cd build
+
+cmake ..
+
+make
+
+cd AttestationApp/CMakeFiles/AppCore.dir/src/AppCore/
+
+g++ -dynamiclib -o libverify.dylib *.o ../../../../../../Build/out/lib/libQuoteVerification.dylib ../../../../../../Build/out/lib/libQuoteVerificationStatic.a ../../../../../../Build/out/lib/libargtable3.a
+
+cp libverify.dylib ../../../../../../../../blindai/lib
+
+cd ../../../../../../Build/out/lib
+
+cp libQuoteVerification.dylib ../../../../../blindai/lib

--- a/client/scripts/postExtensionBuildDarwin.sh
+++ b/client/scripts/postExtensionBuildDarwin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# install_name_tool is used on OSX
+# A replacement for realpath on Linux
 __realpath(){
     local path=$1
     dir=$(dirname $path)
@@ -11,8 +11,13 @@ __realpath(){
         echo $full_dir    
     fi
 }
+
+# install_name_tool is used on OSX
+
 QUOTE_LIB=$(find . -name "_quote_verification*.so")
 BASE_DIR=$(__realpath $(basename ${QUOTE_LIB}))
 cd -
+
+# install_name_tool replaces patchelf on Linux
 install_name_tool -change libverify.dylib "$BASE_DIR/blindai/lib/libverify.dylib" ${QUOTE_LIB}
 install_name_tool -change @rpath/libQuoteVerification.dylib "$BASE_DIR/blindai/lib/libQuoteVerification.dylib" ${QUOTE_LIB}

--- a/client/scripts/postExtensionBuildDarwin.sh
+++ b/client/scripts/postExtensionBuildDarwin.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# install_name_tool is used on OSX
+__realpath(){
+    local path=$1
+    dir=$(dirname $path)
+    if [ $? -eq 0 ];
+    then
+        cd $dir
+        full_dir=$(pwd .)
+        echo $full_dir    
+    fi
+}
+QUOTE_LIB=$(find . -name "_quote_verification*.so")
+BASE_DIR=$(__realpath $(basename ${QUOTE_LIB}))
+cd -
+install_name_tool -change libverify.dylib "$BASE_DIR/blindai/lib/libverify.dylib" ${QUOTE_LIB}
+install_name_tool -change @rpath/libQuoteVerification.dylib "$BASE_DIR/blindai/lib/libQuoteVerification.dylib" ${QUOTE_LIB}

--- a/client/third_party/attestationLib/AttestationCommons/CMakeLists.txt
+++ b/client/third_party/attestationLib/AttestationCommons/CMakeLists.txt
@@ -98,7 +98,7 @@ if(MSVC)
 
     target_compile_definitions(${PROJECT_NAME} PUBLIC _ATTESTATIONCOMMONS_EXPORTS)
     target_compile_definitions(${PROJECT_NAME}Static PUBLIC ATTESTATIONCOMMONS_STATIC)
-else()
+elseif(NOT(APPLE))
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL") # hide external libs symbols in shared object, do not add it for Enclave as we use LDS file here
 endif()
 

--- a/client/third_party/attestationLib/AttestationLibrary/CMakeLists.txt
+++ b/client/third_party/attestationLib/AttestationLibrary/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(${PROJECT_NAME}Static PRIVATE
 if(MSVC)
     target_compile_definitions(${PROJECT_NAME}Static PUBLIC ATTESTATIONLIBRARY_STATIC)
     target_compile_definitions(${PROJECT_NAME} PUBLIC _ATTESTATIONLIBRARY_EXPORTS)
-else()
+elseif(NOT(APPLE))
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL") # hide external libs symbols in shared object, do not add it for Enclave as we use LDS file here
 endif()
 

--- a/client/third_party/attestationLib/AttestationParsers/CMakeLists.txt
+++ b/client/third_party/attestationLib/AttestationParsers/CMakeLists.txt
@@ -128,7 +128,7 @@ if(MSVC)
 
     target_compile_definitions(${PROJECT_NAME} PUBLIC _ATTESTATIONPARSERS_EXPORTS)
     target_compile_definitions(${PROJECT_NAME}Static PUBLIC ATTESTATIONPARSERS_STATIC)
-else()
+elseif(NOT(APPLE))
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL") # hide external libs symbols in shared object, do not add it for Enclave as we use LDS file here
 endif()
 

--- a/client/third_party/attestationLib/CMakeLists.txt
+++ b/client/third_party/attestationLib/CMakeLists.txt
@@ -169,8 +169,8 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE) # adds -fpic/-fpie/-pie
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 		if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
 			message(FATAL_ERROR "Clang 5.0 or above required.")
 		endif()
@@ -190,7 +190,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
 				)
         # implicit-conversion: Checks for suspicious behavior of implicit conversions. Enables implicit-unsigned-integer-truncation, implicit-signed-integer-truncation, and implicit-integer-sign-change.
 		# nullability: Enables nullability-arg, nullability-assign, and nullability-return. While violating nullability does not have undefined behavior, it is often unintentional, so UBSan offers to catch it.
-		set(CMAKE_EXE_LINKER_FLAGS_RELEASE_CLANG "-fsanitize=undefined,safe-stack,implicit-conversion,nullability")
+		if(APPLE)
+			set(CMAKE_EXE_LINKER_FLAGS_RELEASE_CLANG "-fsanitize=undefined,implicit-conversion,nullability")
+		else()
+			set(CMAKE_EXE_LINKER_FLAGS_RELEASE_CLANG "-fsanitize=undefined,safe-stack,implicit-conversion,nullability")
+		endif()
 	endif()
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
@@ -228,10 +232,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
 			"-Wredundant-decls"
 			)
 	if(NOT DEFINED SANITIZE_FLAGS)
-		set(SANITIZE_FLAGS
+		if(NOT(APPLE))
+			set(SANITIZE_FLAGS
 				"-Wl,-z,relro" "-Wl,-z,now" #data relocation and protection (RELRO)
 				"-Wl,-z,noexecstack"       #stack execution protection
 				"-Wl,--no-undefined")
+		endif()
 	endif()
 	set(CMAKE_CXX_FLAGS
 			"${CMAKE_C_FLAGS}"
@@ -247,10 +253,17 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
 	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG -UNDEBUG -UEDEBUG")
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 
+	if(APPLE)
 	set(COMMON_LINKER_FLAGS
-			"-ldl" "-lrt" "-lpthread"
+			"-ldl" "-lpthread"
 			"${SANITIZE_FLAGS}"
 			)
+	else()
+		set(COMMON_LINKER_FLAGS
+				"-ldl" "-lrt" "-lpthread"
+				"${SANITIZE_FLAGS}"
+				)
+	endif()
 
 	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${COMMON_LINKER_FLAGS}" "-pie" "${CMAKE_EXE_LINKER_FLAGS_RELEASE_CLANG}")
 	set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${COMMON_LINKER_FLAGS}")


### PR DESCRIPTION
## Description

Described below are the details for building successfully on macOS (x64) architectures:

1. A new `buildAttestationLibDarwin.sh` shell script is created which separately handles `darwin` platforms.
2. Also, since LLVM's Clang toolchain isn't the same on Apple devices, this condition was factored into Intel's DCAP Attestation Library.
```cmake
if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
```
3. Particularly for the `postExtensionBuildDarwin.sh` shell script, instead of using `patchelf`, on macOS, `install_name_tool` is used to replace `rpath` in the `_quote_verification` bundle file with the necessary absolute paths.

4. The `setup.py` file which builds the python library, is also updated to include building for `darwin`.
```python
SUPPORTED_PLATFORMS = {"LINUX", "WINDOWS", "DARWIN"}
```
## Related Issue

## Type of change

- [x] This change requires a documentation update
- [x] This change affects the client
- [ ] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

Tested on a macOS Big Sur VM with VMWare, and a sample application consuming the server, and it works perfectly!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation according to my changes

<!--- To add when we set tests-->
<!-- 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-- >
