### PR TITLE
show telemetry mode on correct log level

### DIFF
--- a/server/blindai_sgx/src/lib.rs
+++ b/server/blindai_sgx/src/lib.rs
@@ -160,8 +160,9 @@ async fn main(
 
     if std::env::var("BLINDAI_DISABLE_TELEMETRY").is_err() {
         telemetry::setup(telemetry_platform, telemetry_uid)?;
+        info!("Telemetry is enabled.")
     } else {
-        debug!("Telemetry is disabled.")
+        info!("Telemetry is disabled.")
     }
     telemetry::add_event(TelemetryEventProps::Started {}, None);
 


### PR DESCRIPTION
## Description

The server was not showing whenever the telemetry was on or not. 
The issue was that the status message was shown on the wrong log level. 

## Related Issue

N/A

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.

- [x] This change affects the server

## How Has This Been Tested?

CI runned locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
