### PR TITLE
feat(client)!: Add Python context support aka with statement

### DIFF
--- a/client/tests/test_requests.py
+++ b/client/tests/test_requests.py
@@ -21,7 +21,6 @@ from blindai.pb.securedexchange_pb2 import (
 )
 
 from blindai.client import (
-    BlindAiClient,
     ModelDatumType,
     RunModelResponse,
     UploadModelResponse,
@@ -45,10 +44,9 @@ class TestRequest(unittest.TestCase):
         res = UploadModelResponse()
         res.load_from_file(os.path.join(os.path.dirname(__file__), "exec_upload.proof"))
 
-        client = BlindAiClient()
         attestation = res.attestation
         AttestationStub().GetSgxQuoteWithCollateral = Mock(return_value=attestation)
-        client.connect_server(
+        blindai.client.connect(
             "localhost",
             policy=os.path.join(os.path.dirname(__file__), "policy.toml"),
             certificate=os.path.join(os.path.dirname(__file__), "host_server.pem"),
@@ -73,10 +71,9 @@ class TestRequest(unittest.TestCase):
 
         # connect
 
-        client = BlindAiClient()
         attestation = res.attestation
         AttestationStub().GetSgxQuoteWithCollateral = Mock(return_value=attestation)
-        client.connect_server(
+        client = blindai.client.connect(
             "localhost",
             policy=os.path.join(os.path.dirname(__file__), "policy.toml"),
             certificate=os.path.join(os.path.dirname(__file__), "host_server.pem"),
@@ -151,10 +148,9 @@ class TestRequest(unittest.TestCase):
 
         # connect
 
-        client = BlindAiClient()
         attestation = res.attestation
         AttestationStub().GetSgxQuoteWithCollateral = Mock(return_value=attestation)
-        client.connect_server(
+        client = blindai.client.connect(
             "localhost",
             policy=os.path.join(os.path.dirname(__file__), "policy.toml"),
             certificate=os.path.join(os.path.dirname(__file__), "host_server.pem"),
@@ -212,11 +208,9 @@ class TestRequest(unittest.TestCase):
 
         # close server
 
-        self.assertTrue(client.is_connected())
-        client.close_connection()
-        self.assertFalse(client.is_connected())
-        client.close_connection()
-        self.assertFalse(client.is_connected())
+        self.assertFalse(client.closed)
+        client.close()
+        self.assertTrue(client.closed)
 
     @patch("blindai.client.ExchangeStub")
     @patch("blindai.client.AttestationStub")
@@ -249,8 +243,7 @@ class TestRequest(unittest.TestCase):
         )
         AttestationStub().GetCertificate = Mock(return_value=response)
 
-        client = blindai.client.BlindAiClient()
-        client.connect_server("localhost", simulation=True)
+        client = blindai.client.connect("localhost", simulation=True)
 
         # run_model
 
@@ -278,8 +271,6 @@ class TestRequest(unittest.TestCase):
 
         # close server
 
-        self.assertTrue(client.is_connected())
-        client.close_connection()
-        self.assertFalse(client.is_connected())
-        client.close_connection()
-        self.assertFalse(client.is_connected())
+        self.assertFalse(client.closed)
+        client.close()
+        self.assertTrue(client.closed)

--- a/examples/covidnet/BlindAI-COVID-Net.ipynb
+++ b/examples/covidnet/BlindAI-COVID-Net.ipynb
@@ -123,16 +123,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from blindai.client import BlindAiClient, ModelDatumType\n",
+    "import blindai.client\n",
+    "from blindai.client import ModelDatumType\n",
     "\n",
-    "# Launch client\n",
-    "client = BlindAiClient()\n",
+    "# Launch client in simulation mode\n",
+    "client = blindai.client.connect(addr=\"localhost\", simulation=True)\n",
     "\n",
-    "# Simulation mode\n",
-    "client.connect_server(addr=\"localhost\", simulation=True)\n",
-    "\n",
-    "# Hardware mode\n",
-    "# client.connect_server(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
+    "# Launch client in hardware mode\n",
+    "# client = blindai.client.connect(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
    ]
   },
   {
@@ -369,7 +367,7 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "a5388ad2301bd502d89111dcdf0be4de1267e42deee031a75c954f6a954bbfcf"
+   "hash": "d4728e1a3ff73eb9f349d79cccba999964e06e0723f28c97cabf0434506e63b1"
   },
   "kernelspec": {
    "display_name": "Python 3.8.10 ('env': venv)",

--- a/examples/distilbert/BlindAI-DistilBERT.ipynb
+++ b/examples/distilbert/BlindAI-DistilBERT.ipynb
@@ -158,16 +158,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from blindai.client import BlindAiClient, ModelDatumType\n",
+    "import blindai.client\n",
+    "from blindai.client import ModelDatumType\n",
     "\n",
-    "# Launch client\n",
-    "client = BlindAiClient()\n",
+    "# Launch client in simulation mode\n",
+    "client = blindai.client.connect(addr=\"localhost\", simulation=True)\n",
     "\n",
-    "# Simulation mode\n",
-    "client.connect_server(addr=\"localhost\", simulation=True)\n",
-    "\n",
-    "# Hardware mode\n",
-    "# client.connect_server(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
+    "# Launch client in hardware mode\n",
+    "# client = blindai.client.connect(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
    ]
   },
   {

--- a/examples/facenet/BlindAI-Facenet.ipynb
+++ b/examples/facenet/BlindAI-Facenet.ipynb
@@ -233,9 +233,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a480e5a5",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!wget https://raw.githubusercontent.com/mithril-security/blindai/master/examples/facenet/woman_test.jpg"
@@ -355,16 +353,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from blindai.client import BlindAiClient, ModelDatumType\n",
+    "import blindai.client\n",
+    "from blindai.client import ModelDatumType\n",
     "\n",
-    "# Launch client\n",
-    "client = BlindAiClient()\n",
+    "# Launch client in simulation mode\n",
+    "client = blindai.client.connect(addr=\"localhost\", simulation=True)\n",
     "\n",
-    "# Simulation mode\n",
-    "client.connect_server(addr=\"localhost\", simulation=True)\n",
-    "\n",
-    "# Hardware mode\n",
-    "# client.connect_server(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
+    "# Launch client in hardware mode\n",
+    "# client = blindai.client.connect(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
    ]
   },
   {
@@ -490,7 +486,7 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "a5388ad2301bd502d89111dcdf0be4de1267e42deee031a75c954f6a954bbfcf"
+   "hash": "d4728e1a3ff73eb9f349d79cccba999964e06e0723f28c97cabf0434506e63b1"
   },
   "kernelspec": {
    "display_name": "Python 3.8.10 ('env': venv)",

--- a/examples/wav2vec2/BlindAI-Wav2vec2.ipynb
+++ b/examples/wav2vec2/BlindAI-Wav2vec2.ipynb
@@ -311,16 +311,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from blindai.client import BlindAiClient, ModelDatumType\n",
+    "import blindai.client\n",
+    "from blindai.client import ModelDatumType\n",
     "\n",
-    "# Launch client\n",
-    "client = BlindAiClient()\n",
+    "# Launch client in simulation mode\n",
+    "client = blindai.client.connect(addr=\"localhost\", simulation=True)\n",
     "\n",
-    "# Simulation mode\n",
-    "client.connect_server(addr=\"localhost\", simulation=True)\n",
-    "\n",
-    "# Hardware mode\n",
-    "# client.connect_server(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
+    "# Launch client in hardware mode\n",
+    "# client = blindai.client.connect(addr=\"localhost\", policy=\"./policy.toml\", certificate=\"./host_server.pem\")"
    ]
   },
   {

--- a/tests/test_distilbert.py
+++ b/tests/test_distilbert.py
@@ -1,7 +1,8 @@
 from transformers import DistilBertForSequenceClassification
 from transformers import DistilBertTokenizer
 import torch
-from blindai.client import BlindAiClient, ModelDatumType
+import blindai.client
+from blindai.client import ModelDatumType
 import unittest
 import os
 from server import (
@@ -20,59 +21,54 @@ class TestDistilBertBase:
             self.skipTest("no hardware support")
 
     def test_base(self):
-        client = BlindAiClient()
-
-        client.connect_server(
+        with blindai.client.connect(
             addr="localhost",
             simulation=self.simulation,
             policy=policy_file,
             certificate=certificate_file,
-        )
+        ) as client:
 
-        response = client.upload_model(
-            model=model_path,
-            shape=inputs.shape,
-            dtype=ModelDatumType.I64,
-            model_name="test.onnx",
-        )
-        model_id = response.model_id
+            response = client.upload_model(
+                model=model_path,
+                shape=inputs.shape,
+                dtype=ModelDatumType.I64,
+                model_name="test.onnx",
+            )
+            model_id = response.model_id
 
-        response = client.run_model(model_id, run_inputs)
-        origin_pred = model(torch.tensor(run_inputs).unsqueeze(0)).logits.detach()
+            response = client.run_model(model_id, run_inputs)
+            origin_pred = model(torch.tensor(run_inputs).unsqueeze(0)).logits.detach()
 
-        diff = (torch.tensor([response.output]) - origin_pred).sum().abs()
-        self.assertLess(diff, 0.001)  # difference is <0.1%
-        client.delete_model(model_id)
+            diff = (torch.tensor([response.output]) - origin_pred).sum().abs()
+            self.assertLess(diff, 0.001)  # difference is <0.1%
+            client.delete_model(model_id)
 
-    def test_signed(self):
-        client = BlindAiClient()
+        def test_signed(self):
+            with blindai.client.connect(
+                addr="localhost",
+                simulation=self.simulation,
+                policy=policy_file,
+                certificate=certificate_file,
+            ) as client:
+                response = client.upload_model(
+                    model=model_path,
+                    shape=inputs.shape,
+                    dtype=ModelDatumType.I64,
+                    sign=True,
+                )
+                model_id = response.model_id
 
-        client.connect_server(
-            addr="localhost",
-            simulation=self.simulation,
-            policy=policy_file,
-            certificate=certificate_file,
-        )
+                print(response)
+                client.enclave_signing_key.verify(response.signature, response.payload)
 
-        response = client.upload_model(
-            model=model_path,
-            shape=inputs.shape,
-            dtype=ModelDatumType.I64,
-            sign=True,
-        )
-        model_id = response.model_id
+                response = client.run_model(model_id, run_inputs, sign=True)
 
-        print(response)
-        client.enclave_signing_key.verify(response.signature, response.payload)
+                client.enclave_signing_key.verify(response.signature, response.payload)
 
-        response = client.run_model(model_id, run_inputs, sign=True)
+            origin_pred = model(torch.tensor(run_inputs).unsqueeze(0)).logits.detach()
 
-        client.enclave_signing_key.verify(response.signature, response.payload)
-
-        origin_pred = model(torch.tensor(run_inputs).unsqueeze(0)).logits.detach()
-
-        diff = (torch.tensor([response.output]) - origin_pred).sum().abs()
-        self.assertLess(diff, 0.001)  # difference is <0.1%
+            diff = (torch.tensor([response.output]) - origin_pred).sum().abs()
+            self.assertLess(diff, 0.001)  # difference is <0.1%
 
 
 class TestDistilBertSW(TestDistilBertBase, unittest.TestCase):


### PR DESCRIPTION
## Description

The current API can result in the user forgetting to close the connection to the server. This PR introduces support for Python context to the BlindAiClient. It also changes the client interface. The BlindAiClient class has been removed, in favor of a new BlindAiConnection class that can be created via the blindai.client.connect function. 

Client usage before :
```
client = BlindAiClient()
client.connect_server(addr="localhost", simulation=True)
# do something with client...
client.close_connection()
```  

Client usage after the change :
```
with blindai.client.connect(addr="localhost", simulation=True) as client:
  # do something with client...
  client.run_model(model_id, input)
  # implicitly close the connection when exiting the scope
```
When possible we should encourage people to use the interface above, but with statement resources management does not fit all use cases (for instance in our notebooks we need to keep the connection opened between cells). In these circumstances, the connection should be closed manually via the .close() method as shown just below (this is similar to what is currently done) : 
```
client = blindai.client.connect(addr="localhost", simulation=True)
# do something with client...
client.run_model(model_id, input)
# explicitly close the connection
client.close()
```
## Related Issue

Closes #40

## Type of change

 This PR introduces a **breaking change**.

- [x] This change requires a documentation update
- [x] This change affects the client
- [ ] This change affects the server
- [x] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

The tests have been updated to use the new interface when appropriate.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation according to my changes