### PR TITLE
Proper docstring in client API and simulation mode GRPC ambiguity

### DIFF
--- a/client/blindai/client.py
+++ b/client/blindai/client.py
@@ -531,8 +531,8 @@ class BlindAiConnection(contextlib.AbstractContextManager):
 
         Args:
             model (str): Path to Onnx model file.
-            tensor_inputs (Union[List[Any], List[List]]): A list describing multiple inputs of the model.
-            tensor_outputs (Union[ModelDatumType, List[ModelDatumType]): A list describing multiple inputs of the model. Defaults to {"index_0": ModelDatumType.F32}.
+            tensor_inputs (Union[Tuple[List[int], ModelDatumType], List[Tuple[List[int], ModelDatumType]]): The list of input fact and datum types for each input grouped together in lists, describing the different inputs of the model.
+            tensor_outputs (Union[ModelDatumType, List[ModelDatumType]): The list of datum types describing the different output types of the model. Defaults to ModelDatumType.F32
             shape (Tuple, optional): The shape of the model input. Defaults to None.
             dtype (ModelDatumType, optional): The type of the model input data (f32 by default). Defaults to ModelDatumType.F32.
             dtype_out (ModelDatumType, optional): The type of the model output data (f32 by default). Defaults to ModelDatumType.F32.
@@ -608,19 +608,19 @@ class BlindAiConnection(contextlib.AbstractContextManager):
     ) -> RunModelResponse:
         """Send data to the server to make a secure inference.
 
-        The data provided must be in a list, as the tensor will be rebuilt inside the server.
+                The data provided must be in a list, as the tensor will be rebuilt inside the server.
 
-        Args:
-            model_id (str): If set, will run a specific model.
-            data_list (Union[List[Any], List[List[Any]]))): The input data. It must be an array of numbers or an array of arrays of numbers of the same type dtype specified in `upload_model`.
-            sign (bool, optional): Get signed responses from the server or not. Defaults to False.
+                Args:
+                    model_id (str): If set, will run a specific model.
+        data_list (Union[List[Any], List[List[Any]]))): The input data. It must be an array of numbers or an array of arrays of numbers of the same type dtype specified in `upload_model`.
+                    sign (bool, optional): Get signed responses from the server or not. Defaults to False.
 
-        Raises:
-            ConnectionError: Will be raised if the client is not connected.
-            SignatureError: Will be raised if the response signature is invalid
-            ValueError: Will be raised if the connection is closed
-        Returns:
-            RunModelResponse: The response object.
+                Raises:
+                    ConnectionError: Will be raised if the client is not connected.
+                    SignatureError: Will be raised if the response signature is invalid
+                    ValueError: Will be raised if the connection is closed
+                Returns:
+                    RunModelResponse: The response object.
         """
 
         try:

--- a/client/blindai/client.py
+++ b/client/blindai/client.py
@@ -518,7 +518,7 @@ class BlindAiConnection(contextlib.AbstractContextManager):
     def upload_model(
         self,
         model: str,
-        tensor_inputs: Optional[List[List[Any]]] = None,
+        tensor_inputs: Optional[List[Tuple[List[int], ModelDatumType]]] = None,
         tensor_outputs: Optional[List[ModelDatumType]] = None,
         shape: Tuple = None,
         dtype: ModelDatumType = ModelDatumType.F32,
@@ -531,8 +531,8 @@ class BlindAiConnection(contextlib.AbstractContextManager):
 
         Args:
             model (str): Path to Onnx model file.
-            tensor_inputs (Union[Tuple[List[int], ModelDatumType], List[Tuple[List[int], ModelDatumType]]): The list of input fact and datum types for each input grouped together in lists, describing the different inputs of the model.
-            tensor_outputs (Union[ModelDatumType, List[ModelDatumType]): The list of datum types describing the different output types of the model. Defaults to ModelDatumType.F32
+            tensor_inputs (List[Tuple[List[int], ModelDatumType]], optional): The list of input fact and datum types for each input grouped together in lists, describing the different inputs of the model. Defaults to None.
+            tensor_outputs (List[ModelDatumType], optional): The list of datum types describing the different output types of the model. Defaults to ModelDatumType.F32
             shape (Tuple, optional): The shape of the model input. Defaults to None.
             dtype (ModelDatumType, optional): The type of the model input data (f32 by default). Defaults to ModelDatumType.F32.
             dtype_out (ModelDatumType, optional): The type of the model output data (f32 by default). Defaults to ModelDatumType.F32.

--- a/client/blindai/utils/errors.py
+++ b/client/blindai/utils/errors.py
@@ -11,6 +11,8 @@ def check_rpc_exception(rpc_error):
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         return f"Incompatible client/server versions, code={rpc_error.code()} message={rpc_error.details()}"
 
+    elif rpc_error.code() == grpc.StatusCode.FAILED_PRECONDITION:
+        return f"Attestation is not available. Running in Simulation Mode, code={rpc_error.code()} message={rpc_error.details()}"
     else:
         return (
             f"Received RPC error: code={rpc_error.code()} message={rpc_error.details()}"

--- a/server/blindai_sgx/src/untrusted.rs
+++ b/server/blindai_sgx/src/untrusted.rs
@@ -55,7 +55,7 @@ impl Attestation for MyAttestation {
         _request: Request<GetSgxQuoteWithCollateralRequest>,
     ) -> Result<Response<GetSgxQuoteWithCollateralReply>, Status> {
         if cfg!(SGX_MODE = "SW") {
-            return Err(Status::unimplemented(
+            return Err(Status::failed_precondition(
                 "Attestation is not available. Running in Simulation Mode",
             ));
         }


### PR DESCRIPTION
## Description
This PR fixes both the unclear docstrings in the client API and the simulation mode error ambiguity in the client and server.

```python

            model (str): Path to Onnx model file.
            tensor_inputs (Union[Tuple[List[int], ModelDatumType], List[Tuple[List[int], ModelDatumType]]): The list of input fact and datum types for each input grouped together in lists, describing the different inputs of the model.
            tensor_outputs (Union[ModelDatumType, List[ModelDatumType]): The list of datum types describing the different output types of the model. Defaults to ModelDatumType.F32
            shape (Tuple, optional): The shape of the model input. Defaults to None.
            dtype (ModelDatumType, optional): The type of the model input data (f32 by default). Defaults to ModelDatumType.F32.
            dtype_out (ModelDatumType, optional): The type of the model output data (f32 by default). Defaults to ModelDatumType.F32.
            sign (bool, optional): Get signed responses from the server or not. Defaults to False.
            model_name (Optional[str], optional): Name of the model.


```

- For the simulation mode error when building the end-to-end tests, we replace `UNIMPLEMENTED` error code with `FAILED_PRECONDITION` in both the server and the client.
- On the client side:
```python

def check_rpc_exception(rpc_error):
    if rpc_error.code() == grpc.StatusCode.CANCELLED:
        return f"Cancelled GRPC call: code={rpc_error.code()} message={rpc_error.details()}"

    elif rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
        return f"Failed to connect to GRPC server: code={rpc_error.code()} message={rpc_error.details()}"

    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
        return f"Incompatible client/server versions, code={rpc_error.code()} message={rpc_error.details()}"

    elif rpc_error.code() == grpc.StatusCode.FAILED_PRECONDITION:
        return f"Attestation is not available. Running in Simulation Mode, code={rpc_error.code()} message={rpc_error.details()}"
    else:
        return (
            f"Received RPC error: code={rpc_error.code()} message={rpc_error.details()}"
        )

```
- On the server side:
```rust
if cfg!(SGX_MODE = "SW") {
            return Err(Status::failed_precondition(
                "Attestation is not available. Running in Simulation Mode",
            ));
        }
```

## Related Issue

This project accepts pull requests related to open issues. If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please link to the issue here.

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.

- [x] This change requires a documentation update
- [x] This change affects the client
- [x] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

All the client unit tests work perfectly, and the end-to-end tests, also work.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation according to my changes

<!--- To add when we set tests-->
<!-- 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-- >
