### PR TITLE
Increase notebook tests's timeout time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,4 +178,4 @@ jobs:
     
       - name: Test Jupyter notebooks
         run: 
-          pytest --nbmake-timeout=30 --nbmake-kernel=python3 --nbmake examples/**/*.ipynb || (docker logs app; false)
+          pytest --nbmake-timeout=40 --nbmake-kernel=python3 --nbmake examples/**/*.ipynb || (docker logs app; false)


### PR DESCRIPTION
## Description

Prevent the notebook tests from failing when github's server is busy

## Type of change

- [x] This change only concerns the tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!--- To add when we set tests-->
<!-- 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-- >
