### PR TITLE
change the client tests github actions so that it runs on any pushes that change the client

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,9 +1,6 @@
 name: Run Python Tests
 on:
-  pull_request:
-    branches:
-      - master
-      - main
+  push:
     paths: 'client/**'
 
 jobs:


### PR DESCRIPTION
## Description

change the client tests github actions so that it runs on any pushes that change the client

## Related Issue

All of the other workflows where running on push and this was the only one who was triggered on pull request.

## Type of change

- [x] This change only concerns the CI.

<!--- To add when we set tests-->
<!-- 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-- >
