### PR TITLE
change link so it redirects toward website

### DIFF
--- a/docs/pdoc_template/logo.mako
+++ b/docs/pdoc_template/logo.mako
@@ -1,5 +1,5 @@
 <header>
-    <a class="homelink" rel="home" title="blindai Home" href="https://blindai.mithrilsecurity.io">
+    <a class="homelink" rel="home" title="blindai Home" href="https://mithrilsecurity.io">
         <img style="max-width: 225px; max-height: 150px" src="/assets/logo.png" alt=""> BlindAI
     </a>
 </header>


### PR DESCRIPTION
the logo link in the API reference was redirecting toward the latest version of the docs, which could have been problematics for the user. So instead I prefer it redirects toward the main site.

- [x] This change only concerns documentation