### PR TITLE
CD 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,16 +179,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    #needs: run-tests
+    needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
     if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Copy TEST
-        run: |
-          echo "TEST" > TEST
 
       # Login
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,6 @@ jobs:
 
   push-docker:
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
-    if: github.ref == 'refr/heads/deployment-dockerhub'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,10 @@ jobs:
             -t ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest \
             -f ./docker/build.dockerfile \
             .
-          docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > ../examples/policy.toml
+
+      - name: Copy policy
+        run: |
+          docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > examples/policy.toml
 
       # Push docker image (blindai-server)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,12 +179,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: run-tests
+    #needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
     if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Copy TEST
+        run: |
+          echo "TEST" > TEST
 
       # Login
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,8 @@ jobs:
       # Push docker image (blindai-server)
 
       - name: Private registry blindai-server push
-        run: docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
+        run: docker push andreiglesias/blindai-repo-test:latest 
+        #docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
 
       # Build docker image (blindai-server-sim)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    #sneeds: run-tests
+    needs: run-tests
     if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout
@@ -215,11 +215,9 @@ jobs:
 
       - name: Commit and push the policy
         uses: devops-infra/action-commit-push@master
-        #uses: maxgfr/github-commit-push-file@main
         with:
-          #commit_name: 'Update blindai-server policy'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_message: Replaced foo with bar
+          commit_message: Update blindai-server policy
 
       # Push docker image (blindai-server)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,8 +181,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
-    if: github.ref == 'refr/heads/deployment-dockerhub'
     steps:
+    if: github.ref == 'refs/heads/deployment-dockerhub'
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
-    if: github.ref == 'refr/heads/deployment-dockerhub'
+    #if: github.ref == 'refr/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,8 +222,7 @@ jobs:
       # Push docker image (blindai-server)
 
       - name: Dockerhub blindai-server push
-        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest 
-        #docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest
 
       # Build docker image (blindai-server-sim)
 
@@ -240,9 +239,7 @@ jobs:
       # Push docker image (blindai-server-sim)
 
       - name: Dockerhub blindai-server-sim push
-        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest 
-        # docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
-
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest
 
       # Build docker image (blindai-server-dcsv3)
 
@@ -259,5 +256,4 @@ jobs:
       # Push docker image (blindai-server-dcsv3)
 
       - name: Dockerhub blindai-server-dcsv3 push
-        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest 
-        #docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,8 +179,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: run-tests
-    #if: github.ref == 'refs/heads/deployment-dockerhub'
+    #needs: run-tests
+    if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
     #if: github.ref == 'refr/heads/deployment-dockerhub'
     steps:
@@ -201,14 +202,14 @@ jobs:
           make init
           DOCKER_BUILDKIT=1 docker build \
             --target hardware \
-            -t mithrilsecuritysas/blindai-server:latest \
+            -t ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest \
             -f ./docker/build.dockerfile \
             .
 
       # Push docker image (blindai-server)
 
       - name: Private registry blindai-server push
-        run: docker push andreiglesias/blindai-repo-test:latest 
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
 
       # Build docker image (blindai-server-sim)
@@ -219,14 +220,15 @@ jobs:
           make init
           DOCKER_BUILDKIT=1 docker build \
             --target software \
-            -t mithrilsecuritysas/blindai-server-sim:latest \
+            -t ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest \
             -f ./docker/build.dockerfile \
             .
 
       # Push docker image (blindai-server-sim)
 
       - name: Private registry blindai-server-sim push
-        run: docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest 
+        # docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
 
 
       # Build docker image (blindai-server-dcsv3)
@@ -237,11 +239,12 @@ jobs:
           make init
           DOCKER_BUILDKIT=1 docker build \
             --target hardware-dcsv3 \
-            -t mithrilsecuritysas/blindai-server-dcsv3:latest \
+            -t ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest \
             -f ./docker/build.dockerfile \
             .
 
       # Push docker image (blindai-server-dcsv3)
 
       - name: Private registry blindai-server-dcsv3 push
-        run: docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest
+        run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest 
+        #docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
 
       # Push docker image (blindai-server-sim)
 
-      - name: [Dockerhub Push] blindai-server-sim
+      - name: \[Dockerhub Push\] blindai-server-sim
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest 
         # docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
 
@@ -258,6 +258,6 @@ jobs:
 
       # Push docker image (blindai-server-dcsv3)
 
-      - name: [Dockerhub Push] blindai-server-dcsv3
+      - name: \[Dockerhub Push\] blindai-server-dcsv3
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,8 +181,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
-    steps:
     if: github.ref == 'refs/heads/deployment-dockerhub'
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,11 +156,11 @@ jobs:
         run: pip install /tmp/client-artifacts/*.whl
 
       # Run tests
-      
+
       - name: Launch server
         run: |
           docker kill -f app > /dev/null 2>&1 || true
-          docker run --rm -d -e BLINDAI_DISABLE_TELEMETRY=1 -p 50051:50051 -p 50052:50052 --name app mithrilsecuritysas/${{ matrix.serverImage }}:latest 
+          docker run --rm -d -e BLINDAI_DISABLE_TELEMETRY=1 -p 50051:50051 -p 50052:50052 --name app mithrilsecuritysas/${{ matrix.serverImage }}:latest
 
       - name: Copy policy and certificate
         run: |
@@ -173,3 +173,71 @@ jobs:
           BLINDAI_TEST_NO_LAUNCH_SERVER: 'true'
           BLINDAI_TEST_NO_HW: 'true'
           BLINDAI_TEST_SKIP_COVIDNET: 'true'
+
+  push-docker:
+    name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
+    if: github.ref == 'refr/heads/deployment-dockerhub'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Login
+
+      - name: Login to registry.mithrilsecurity.io
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.REGISTRY_PRIV_USR }}
+          password: ${{ secrets.REGISTRY_PRIV_PWD }}
+
+      # Build docker image (blindai-server)
+
+      - name: Build blindai-server
+        run: |
+          cd server
+          make init
+          DOCKER_BUILDKIT=1 docker build \
+            --target hardware \
+            -t mithrilsecuritysas/blindai-server:latest \
+            -f ./docker/build.dockerfile \
+            .
+
+      # Push docker image (blindai-server)
+
+      - name: Private registry blindai-server push
+        run: docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
+
+      # Build docker image (blindai-server-sim)
+
+      - name: Build blindai-server-sim
+        run: |
+          cd server
+          make init
+          DOCKER_BUILDKIT=1 docker build \
+            --target software \
+            -t mithrilsecuritysas/blindai-server-sim:latest \
+            -f ./docker/build.dockerfile \
+            .
+
+      # Push docker image (blindai-server-sim)
+
+      - name: Private registry blindai-server-sim push
+        run: docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
+
+
+      # Build docker image (blindai-server-dcsv3)
+
+      - name: Build blindai-server-dcsv3
+        run: |
+          cd server
+          make init
+          DOCKER_BUILDKIT=1 docker build \
+            --target hardware-dcsv3 \
+            -t mithrilsecuritysas/blindai-server-dcsv3:latest \
+            -f ./docker/build.dockerfile \
+            .
+
+      # Push docker image (blindai-server-dcsv3)
+
+      - name: Private registry blindai-server-dcsv3 push
+        run: docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,9 +206,18 @@ jobs:
             -f ./docker/build.dockerfile \
             .
 
+      # Copy policy
+
       - name: Copy policy
         run: |
           docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > examples/policy.toml
+
+      # Commit and push the file
+
+      - name: Commit and push the policy
+        uses: maxgfr/github-commit-push-file@main
+        with:
+          commit_name: 'Update blindai-server policy'
 
       # Push docker image (blindai-server)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: run-tests
-    if: github.ref == 'refs/heads/deployment-dockerhub'
+    #if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -214,9 +214,10 @@ jobs:
       # Commit and push the policy
 
       - name: Commit and push the policy
-        uses: maxgfr/github-commit-push-file@main
+        uses: devops-infra/action-commit-push@master
         with:
-          commit_name: 'Update blindai-server policy'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: 'Update blindai-server policy'
 
       # Push docker image (blindai-server)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: run-tests
+    #needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
     #if: github.ref == 'refr/heads/deployment-dockerhub'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
 
       # Push docker image (blindai-server)
 
-      - name: [Dockerhub Push] blindai-server
+      - name: Dockerhub Push - blindai-server
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
 
@@ -239,7 +239,7 @@ jobs:
 
       # Push docker image (blindai-server-sim)
 
-      - name: \[Dockerhub Push\] blindai-server-sim
+      - name: Dockerhub Push blindai-server-sim
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest 
         # docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
 
@@ -258,6 +258,6 @@ jobs:
 
       # Push docker image (blindai-server-dcsv3)
 
-      - name: \[Dockerhub Push\] blindai-server-dcsv3
+      - name: Dockerhub Push - blindai-server-dcsv3
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,7 @@ jobs:
 
       # Login
 
-      - name: Login to registry.mithrilsecurity.io
+      - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.REGISTRY_PRIV_USR }}
@@ -211,7 +211,7 @@ jobs:
         run: |
           docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > examples/policy.toml
 
-      # Commit and push the file
+      # Commit and push the policy
 
       - name: Commit and push the policy
         uses: maxgfr/github-commit-push-file@main
@@ -220,7 +220,7 @@ jobs:
 
       # Push docker image (blindai-server)
 
-      - name: Private registry blindai-server push
+      - name: [Dockerhub Push] blindai-server
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server:latest
 
@@ -238,7 +238,7 @@ jobs:
 
       # Push docker image (blindai-server-sim)
 
-      - name: Private registry blindai-server-sim push
+      - name: [Dockerhub Push] blindai-server-sim
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-sim:latest 
         # docker push registry.mithrilsecurity.io/blindai/blindai-server-sim:latest
 
@@ -257,6 +257,6 @@ jobs:
 
       # Push docker image (blindai-server-dcsv3)
 
-      - name: Private registry blindai-server-dcsv3 push
+      - name: [Dockerhub Push] blindai-server-dcsv3
         run: docker push ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server-dcsv3:latest 
         #docker push registry.mithrilsecurity.io/blindai/blindai-server-dcsv3:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,9 +205,9 @@ jobs:
             -f ./docker/build.dockerfile \
             .
 
-      # Copy policy
+      # Update policy
 
-      - name: Copy policy
+      - name: Update policy
         run: |
           docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > examples/policy.toml
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,9 +179,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    #needs: run-tests
+    needs: run-tests
     name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
-    #if: github.ref == 'refr/heads/deployment-dockerhub'
+    if: github.ref == 'refr/heads/deployment-dockerhub'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -205,6 +205,7 @@ jobs:
             -t ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest \
             -f ./docker/build.dockerfile \
             .
+          docker run --rm ${{ secrets.REGISTRY_PRIV_USR }}/blindai-server:latest cat /root/policy.toml > ../examples/policy.toml
 
       # Push docker image (blindai-server)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,6 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: run-tests
-    name: Push blindai-server, blindai-server-sim, blindai-server-dcsv3 to priv and pub registry
     if: github.ref == 'refs/heads/deployment-dockerhub'
     steps:
       - name: Checkout

--- a/client/setup.py
+++ b/client/setup.py
@@ -1,4 +1,3 @@
-
 from operator import sub
 import os
 import setuptools

--- a/client/setup.py
+++ b/client/setup.py
@@ -1,3 +1,4 @@
+
 from operator import sub
 import os
 import setuptools


### PR DESCRIPTION
## Description

[CD] Automate the creation and publish (dockerhub) of the docker images after the push in the deployment-dockerhub after the tests in main.yml:

Build:
- blindai-server 
- blindai-server-sim
- blindai-server-dcsv3

Extract the policy from the image blindai-server to replace `examples/policy.toml`

Push to dockerhub all images

SECRETS:
Creds: REGISTRY_PRIV_PWD & REGISTRY_PRIV_USR

## Related Issue

The release of a new version of BlindAI has to be done manually.

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.

- [ ] This change requires a documentation update
- [ ] This change affects the client
- [X] This change affects the server
- [ ] This change affects the API
- [ ] This change only concerns the documentation

## How Has This Been Tested?

It was tested with a Dockerhub account for testing.
