### PR TITLE
add daily job to delete models after 1 week of inactivity

### DIFF
--- a/server/blindai_sgx/src/client_communication.rs
+++ b/server/blindai_sgx/src/client_communication.rs
@@ -511,16 +511,6 @@ impl Exchange for Exchanger {
             return Err(Status::invalid_argument("Model doesn't exist"));
         }
 
-        let user_id = if let Some(auth_ext) = auth_ext.as_ref() {
-            if let Some(id) = auth_ext.userid() {
-                Some(id.to_string())
-            } else {
-                return Err(Status::unauthenticated("You must provide an api key"));
-            }
-        } else {
-            None
-        };
-
         let username = match auth_ext.as_ref() {
             Some(auth_ext) => match auth_ext.username() {
                 Some(username) => username.into(),
@@ -530,7 +520,7 @@ impl Exchange for Exchanger {
         };
 
         // Delete the model
-        if self.model_store.delete_model(&model_id, user_id.as_deref(), username.as_deref()).is_none() {
+        if self.model_store.delete_model(&model_id, username.as_deref()).is_none() {
             error!("Model doesn't exist");
             return Err(Status::invalid_argument("Model doesn't exist"));
         }

--- a/server/blindai_sgx/src/lib.rs
+++ b/server/blindai_sgx/src/lib.rs
@@ -24,6 +24,9 @@ use std::{ffi::CStr, sync::Arc};
 use log::*;
 use sgx_types::*;
 use std::io::Read;
+
+use tokio::{spawn, time::{sleep, Duration}};
+
 use tonic::transport::ServerTlsConfig;
 
 use tonic::transport::{Identity, Server};
@@ -111,7 +114,7 @@ async fn main(telemetry_platform: String, telemetry_uid: String) -> Result<()> {
 
     let metadata_folder = Path::new("./metadata").exists();
 
-    if (!metadata_folder) {
+    if !metadata_folder {
         fs::create_dir("./metadata")?;
     }
 
@@ -136,7 +139,7 @@ async fn main(telemetry_platform: String, telemetry_uid: String) -> Result<()> {
         fs::read("tls/host_server.key").context("Opening tls/host_server.key file")?;
     let untrusted_identity = Identity::from_pem(&untrusted_cert, &untrusted_key);
 
-    tokio::spawn({
+    spawn({
         let network_config = config.clone();
         async move {
             info!(
@@ -174,37 +177,50 @@ async fn main(telemetry_platform: String, telemetry_uid: String) -> Result<()> {
         config.clone(),
     );
 
-    let server_future = Server::builder()
-        .tls_config(ServerTlsConfig::new().identity((&enclave_identity).into()))?
-        .max_frame_size(Some(65536))
-        .add_service(ExchangeServer::with_interceptor(
-            exchanger,
-            auth::auth_interceptor,
-        ))
-        .serve(config.client_to_enclave_attested_socket()?);
+    spawn(
+        async move {
+            info!(
+                "Starting server for User --> Enclave (attested TLS) trusted communication at {}",
+                config.client_to_enclave_attested_url
+            );
+            let server = Server::builder()
+            .tls_config(ServerTlsConfig::new().identity((&enclave_identity).into()))?
+            .max_frame_size(Some(65536))
+            .add_service(ExchangeServer::with_interceptor(
+                exchanger,
+                auth::auth_interceptor,
+            ))
+            .serve(config.client_to_enclave_attested_socket()?);
 
-    info!(
-        "Starting server for User --> Enclave (attested TLS) trusted communication at {}",
-        config.client_to_enclave_attested_url
-    );
-    println!("Server started, waiting for commands");
+            println!("Server started, waiting for commands");
 
-    if cfg!(SGX_MODE = "SW") {
-        info!("Server running in simulation mode, attestation not available.");
+            if cfg!(SGX_MODE = "SW") {
+                info!("Server running in simulation mode, attestation not available.");
+            }
+        
+            if std::env::var("BLINDAI_DISABLE_TELEMETRY").is_err() {
+                telemetry::setup(config.clone(), telemetry_platform, telemetry_uid)
+                    .context("Setting up telemetry")?;
+                info!("Telemetry is enabled.")
+            } else {
+                info!("Telemetry is disabled.")
+            }
+            telemetry::add_event(TelemetryEventProps::Started {}, None, None);
+
+            server.await
+            .context("Running User --> Enclave (attested TLS) server")?;
+            Ok::<(), Error>(())
+    });
+
+    loop {
+        sleep(Duration::from_secs(60 * 60 * 24)).await;
+        spawn({
+            let model_store = model_store.clone();
+            async move {
+                info!("Daily cleanup started");
+                let nb = model_store.prune_old_models();
+                info!("{} models deleted", nb);
+                Ok::<(), Error>(())
+    }});
     }
-
-    if std::env::var("BLINDAI_DISABLE_TELEMETRY").is_err() {
-        telemetry::setup(config.clone(), telemetry_platform, telemetry_uid)
-            .context("Setting up telemetry")?;
-        info!("Telemetry is enabled.")
-    } else {
-        info!("Telemetry is disabled.")
-    }
-    telemetry::add_event(TelemetryEventProps::Started {}, None, None);
-
-    server_future
-        .await
-        .context("Running User --> Enclave (attested TLS) server")?;
-
-    Ok(())
 }

--- a/server/blindai_sgx/src/model_store.rs
+++ b/server/blindai_sgx/src/model_store.rs
@@ -71,7 +71,7 @@ pub struct UsersMap {
 
 trait ModelClock {
     fn get_oldest_loaded(&mut self) -> Option<&mut StoredModel>;
-    fn get_oldest_unloaded(&self) -> Option<(&str, SystemTime)>;
+    fn get_oldest_unloaded(&self) -> Option<(&str, Option<&str>, SystemTime)>;
 }
 
 impl ModelClock for ModelsMap {
@@ -97,7 +97,7 @@ impl ModelClock for ModelsMap {
         return oldest;
     }
 
-    fn get_oldest_unloaded(&self) -> Option<(&str, SystemTime)> {
+    fn get_oldest_unloaded(&self) -> Option<(&str, Option<&str>, SystemTime)> {
         let mut oldest = SystemTime::now();
         let mut oldest_id = "";
         if self.map.is_empty() {
@@ -109,7 +109,7 @@ impl ModelClock for ModelsMap {
                 oldest_id = k;
             }
         }
-        return Some((oldest_id, oldest));
+        return Some((oldest_id, None, oldest));
     }
 }
 
@@ -134,8 +134,8 @@ impl ModelClock for UsersMap {
         return oldest;
     }
 
-    fn get_oldest_unloaded(&self) -> Option<(&str, SystemTime)> {
-        let mut oldest: Option<(&str, SystemTime)> = None;
+    fn get_oldest_unloaded(&self) -> Option<(&str, Option<&str>, SystemTime)> {
+        let mut oldest: Option<(&str, Option<&str>, SystemTime)> = None;
         if self.map.is_empty() {
             return None;
         }
@@ -147,11 +147,11 @@ impl ModelClock for UsersMap {
                 if let None = oldest {
                     oldest = Some(o);
                 } else {
-                    oldest = oldest.map(|(model_id, time)| {
-                        if time > o.1 {
-                            (o.0, o.1)
+                    oldest = oldest.map(|(model_id, username, time)| {
+                        if time > o.2 {
+                            (o.0, k.as_deref(), o.2)
                         } else {
-                            (model_id, time)
+                            (model_id, username, time)
                         }
                     });
                 }
@@ -269,7 +269,7 @@ impl ModelStore {
             if save_model {
                 if models.map.len() >= self.config.max_sealed_model_per_user.unwrap_or(usize::max_value()) {
                     info!("User sealed model limit reached. The oldest model used will be deleted...");
-                    let (oldest_id, _) = models.get_oldest_unloaded().unwrap();
+                    let (oldest_id, _, _) = models.get_oldest_unloaded().unwrap();
                     let oldest_id = oldest_id.to_owned();
                     if let Some(path) = path_from_key(&self.config.models_path, &oldest_id) {
                         let _ = fs::remove_file(path);
@@ -367,18 +367,10 @@ impl ModelStore {
 
     /// If user_id is provided, it will fail if the model is not owned by this
     /// user. This will never remove startup models.
-    pub fn delete_model(&self, model_id: &str, user_id: Option<&str>, username: Option<&str>) -> Option<()> {
+    pub fn delete_model(&self, model_id: &str, username: Option<&str>) -> Option<()> {
         if let Some(key) = key_from_id_and_username(model_id, username) {
             let mut write_guard = self.inner.write().unwrap();
             if let Some(map) = write_guard.models.map.get_mut(&username.map(str::to_string)) {
-                let owner = user_id.map(|id| id.parse::<usize>().unwrap());
-                if let Some(user) = owner {
-                    if map.owner_id != user {
-                        drop(write_guard);
-                        info!("Attempt at deleting a model from unauthorized namespace {:?} userid:{:?}", model_id, user_id);
-                        return None;
-                    }
-                }
                 if let Some(_) = map.map.remove(&key).and_then(|m| m.model) {
                     map.nb_loaded_models -= 1;
                     write_guard.models.nb_loaded_models -= 1;
@@ -390,6 +382,28 @@ impl ModelStore {
             }
         }
         None
+    }
+
+    pub fn prune_old_models(&self) -> usize {
+        let mut nb = 0;
+        loop {
+            let mut model = None;
+            {
+                let read_guard = self.inner.read().unwrap(); // take read lock
+                if let Some((model_id, username, last_use)) = read_guard.models.get_oldest_unloaded() {
+                    if SystemTime::now() - std::time::Duration::from_secs(60 * 60 * 24 * 7) >= last_use {
+                        model = Some((model_id.to_string(), username.map(|s| s.to_string())));
+                        nb += 1
+                    }
+                }
+            }
+            if let Some((model_id, username)) = model {
+                self.delete_model(&model_id, username.as_deref());
+                info!("model {} owned by user {:?} automatically removed", &model_id, username.as_deref());
+            } else {
+                break nb
+            }
+        }
     }
 
     pub fn check_seal_file_exist(&self) -> Result<()> {


### PR DESCRIPTION
## Description

put the communication server in a tokio task.
instead a loop wait 24h before creating a task deleting unusued models.

## Related Issue

prevents disk storage to increase indifinitively

## Type of change
The types of changes must be deduced from the labels of the related issues. Please consider providing these further details.

This change affects the client. It may need to be documented.

## How Has This Been Tested?

Tested locally.
